### PR TITLE
Unify number formatting and button style shades

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Magical Clicker Ver.0.1.1.13</title>
   <link rel="stylesheet" href="./style.css">
-<style>.milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);} .buttons .row{display:flex;gap:.5rem} .buttons .row > .btn{flex:1}</style><style>.btn.buy1,.btn.buyMax{background:#2d7;border-color:#2d7;}.btn.buyMax{filter:brightness(0.9);}.btn.up1,.btn.upMax{background:#276bd1;border-color:#276bd1;}.btn.upMax{filter:brightness(0.9);}.buttons .row{display:flex;gap:.5rem} .buttons .row>button{flex:1}</style>
+  <style>
+    .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}
+    .buttons .row{display:flex;gap:.5rem}
+    .buttons .row > .btn{flex:1}
+  </style>
 </head>
 <body>
   <div class="container">

--- a/js/ui.js
+++ b/js/ui.js
@@ -18,12 +18,13 @@ function maxAffordableClick(state){
 
 export function renderClick(state){
   const gain = clickGainByLevel(state.clickLv);
-  setText('tapGain', '+' + (gain<10?gain.toFixed(2):gain.toFixed(0)));
+  setText('tapGain', '+' + fmt(gain));
 
   setText('clickLvInfo', `Lv ${state.clickLv}`);
-  setText('clickDelta', (clickNextDelta(state.clickLv)).toFixed(2));
+  const delta = clickNextDelta(state.clickLv);
+  setText('clickDelta', (delta>=0?'+':'') + fmt(delta));
   setText('clickCost', fmt(clickNextCost(state.clickLv)));
-  setText('clickAfter', '+' + clickGainByLevel(state.clickLv+1).toFixed(2));
+  setText('clickAfter', '+' + fmt(clickGainByLevel(state.clickLv+1)));
 
   const b1 = document.getElementById('upgradeClick');
   const bm = document.getElementById('upgradeClickMax');

--- a/style.css
+++ b/style.css
@@ -109,7 +109,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
   --buy:#2a78ff; --buy-deep:#1d56b8;
   --upg:#9b5cff; --upg-deep:#6a39c2;
 }
-.btn-buy{background:linear-gradient(180deg,var(--buy)0%,var(--buy-deep)100%);color:#fff;}
-.btn-buy-agg{background:linear-gradient(180deg,var(--buy-deep)0%,#143a74100%);color:#fff;}
-.btn-upg{background:linear-gradient(180deg,var(--upg)0%,var(--upg-deep)100%);color:#fff;}
-.btn-upg-agg{background:linear-gradient(180deg,var(--upg-deep)0%,#3f1d84100%);color:#fff;}
+.btn-buy{background:linear-gradient(180deg,var(--buy) 0%,var(--buy-deep) 100%);color:#fff;}
+.btn-buy-agg{background:linear-gradient(180deg,var(--buy-deep) 0%,#143a74 100%);color:#fff;}
+.btn-upg{background:linear-gradient(180deg,var(--upg) 0%,var(--upg-deep) 100%);color:#fff;}
+.btn-upg-agg{background:linear-gradient(180deg,var(--upg-deep) 0%,#3f1d84 100%);color:#fff;}


### PR DESCRIPTION
## Summary
- Format tap gain and click upgrade numbers using the global formatter
- Fix purchase/upgrade button gradients and remove obsolete inline styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34e58f70c8331a5a137f159621946