### PR TITLE
Fix format toggle and update version to 0.1.1.15

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magical Clicker Ver.0.1.1.13</title>
+  <title>Magical Clicker Ver.0.1.1.15</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.1.11 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.1.15 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-export const VERSION = 'Ver.0.1.1.13';
+export const VERSION = 'Ver.0.1.1.15';
 import { GENERATORS } from './data.js';
 import { save, load, reset } from './save.js';
 import { renderAll, renderKPI, lightRefresh, bindFormatToggle } from './ui.js';
@@ -54,7 +54,7 @@ document.getElementById('resetBtn').addEventListener('click', ()=>{
 // initial render
 update();
 try{ const v=document.getElementById('version'); if(v) v.textContent = VERSION; }catch{}
-try{ bindFormatToggle && bindFormatToggle(); }catch{}
+try{ bindFormatToggle && bindFormatToggle(state); }catch{}
 
 
 import { totalPps } from './economy.js';
@@ -77,4 +77,4 @@ function __loop(ts){
 requestAnimationFrame(__loop);
 
 
-try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.1.13'; }catch(e){}
+try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.1.15'; }catch(e){}

--- a/js/ui.js
+++ b/js/ui.js
@@ -106,19 +106,19 @@ function genRow(state, g, onUpdate){
 
   // compute affordability atomically to avoid transient flash
   const costBuy1 = nextUnitCost(g);
-  const canBuy1  = state.money >= costBuy1;
+  const canBuy1  = state.power >= costBuy1;
 
   const costUp1  = nextUpgradeCost(g);
-  const canUp1   = state.money >= costUp1;
+  const canUp1   = state.power >= costUp1;
 
   let needToNext = (10 - ((g.level|0)%10)) % 10;
-  const canUpM = canUp1 && (needToNext > 1 ? (state.money >= costUp1 * needToNext) : canUp1);
+  const canUpM = canUp1 && (needToNext > 1 ? (state.power >= costUp1 * needToNext) : canUp1);
 
   // choose a simple bulk rule for buyMax (at least 2 units with current money)
   let canBuyM = false;
   if (canBuy1) {
     const price1 = costBuy1;
-    const maxN = Math.floor(state.money / price1);
+    const maxN = Math.floor(state.power / price1);
     canBuyM = maxN >= 2;
   }
 
@@ -186,11 +186,15 @@ export function renderAll(state){
   renderKPI(state); renderClick(state); renderGens(state);
 }
 
-export function bindFormatToggle(){
+export function bindFormatToggle(state){
   const btn = document.getElementById('fmtToggle');
   if(!btn) return;
   const apply = ()=>{ btn.textContent = (getFormatMode()==='eng' ? '表記：工学式' : '表記：日本式'); };
-  btn.addEventListener('click', ()=>{ setFormatMode(getFormatMode()==='eng' ? 'jp' : 'eng'); apply(); });
+  btn.addEventListener('click', ()=>{
+    setFormatMode(getFormatMode()==='eng' ? 'jp' : 'eng');
+    apply();
+    if(state) renderAll(state);
+  });
   apply();
 }
 
@@ -255,17 +259,17 @@ export function lightRefresh(state){
 
   // compute affordability atomically to avoid transient flash
   const costBuy1 = nextUnitCost(g);
-  const canBuy1  = state.money >= costBuy1;
+  const canBuy1  = state.power >= costBuy1;
 
   const costUp1  = nextUpgradeCost(g);
-  const canUp1   = state.money >= costUp1;needToNext = (10 - ((g.level|0)%10)) % 10;
-  const canUpM = canUp1 && (needToNext > 1 ? (state.money >= costUp1 * needToNext) : canUp1);
+  const canUp1   = state.power >= costUp1;needToNext = (10 - ((g.level|0)%10)) % 10;
+  const canUpM = canUp1 && (needToNext > 1 ? (state.power >= costUp1 * needToNext) : canUp1);
 
   // choose a simple bulk rule for buyMax (at least 2 units with current money)
   let canBuyM = false;
   if (canBuy1) {
     const price1 = costBuy1;
-    const maxN = Math.floor(state.money / price1);
+    const maxN = Math.floor(state.power / price1);
     canBuyM = maxN >= 2;
   }
 

--- a/style.css
+++ b/style.css
@@ -104,7 +104,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.1.10 UI color refinements === */
+/* === 0.1.1.15 UI color refinements === */
 :root{
   --buy:#2a78ff; --buy-deep:#1d56b8;
   --upg:#9b5cff; --upg-deep:#6a39c2;


### PR DESCRIPTION
## Summary
- fix generator affordability calculations by using `state.power`
- re-render numbers when switching Japanese/engineering formats
- bump version text to 0.1.1.15

## Testing
- `node --check js/format.js js/main.js js/ui.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35151eaf48331808e86de85a31741