### PR TITLE
fix generator bulk upgrades and format numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magical Clicker Ver.0.1.1.15</title>
+  <title>Magical Clicker Ver.0.1.1.16</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.1.15 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.1.16 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }
@@ -25,20 +25,26 @@ function trimFixed(num, dec){
 
 /* ===== ENG ===== */
 function fmtENG(n){
-  const sgn = n<0?'-':''; const a=Math.abs(n);
+  const sgn = n<0?'-':''; let a=Math.abs(n);
   if(a===0) return '0';
-  if(a>=0.01 && a<1000){
-    const r=roundSig3(a);
-    const dec=Math.max(0,2-abs10exp(r));
-    return sgn+r.toFixed(dec);
+
+  // try normal notation (0.01 <= x < 100)
+  const normal = Math.round(a*100)/100;
+  if(normal >= 0.01 && normal < 100){
+    const dec = Math.min(2, Math.max(0, 2-abs10exp(normal)));
+    return sgn + normal.toFixed(dec);
   }
-  const exp=abs10exp(a);
-  const exp3=Math.floor(exp/3)*3;
-  const mant=a/10**exp3;
-  const mr=roundSig3(mant);
-  const dec=Math.max(0,2-abs10exp(mr));
-  const mstr=mr.toFixed(dec);
-  return sgn+mstr+'e'+exp3;
+  if(normal >=100 && normal < 1000){
+    return sgn + normal.toFixed(0);
+  }
+
+  // engineering notation
+  const r = roundSig3(a);
+  const exp = abs10exp(r);
+  const exp3 = Math.floor(exp/3)*3;
+  const mant = r / 10**exp3;
+  const dec = Math.min(2, Math.max(0, 2-abs10exp(mant)));
+  return sgn + mant.toFixed(dec) + 'e' + exp3;
 }
 
 /* ===== JP ===== */
@@ -52,7 +58,7 @@ function fmtJP(n){
   if(a===0) return '0';
   a=roundSig3(a);
   if(a<10000){
-    const dec=Math.max(0,2-abs10exp(a));
+    const dec=Math.min(2, Math.max(0,2-abs10exp(a)));
     return sgn+trimFixed(a,dec);
   }
   const exp=abs10exp(a);

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-export const VERSION = 'Ver.0.1.1.15';
+export const VERSION = 'Ver.0.1.1.16';
 import { GENERATORS } from './data.js';
 import { save, load, reset } from './save.js';
 import { renderAll, renderKPI, lightRefresh, bindFormatToggle } from './ui.js';
@@ -77,4 +77,4 @@ function __loop(ts){
 requestAnimationFrame(__loop);
 
 
-try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.1.15'; }catch(e){}
+try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.1.16'; }catch(e){}

--- a/js/ui.js
+++ b/js/ui.js
@@ -88,90 +88,73 @@ function genRow(state, g, onUpdate){
   `;
 
   const ownEl = row.querySelector('.own');
-  const eachEl= row.querySelector('.eachPps');
-  
+  const eachEl = row.querySelector('.eachPps');
 
-  const btnBuy1=row.querySelector('.buy1');
-  const btnBuyM=row.querySelector('.buyMax');
-  const btnUp1 =row.querySelector('.up1');
-  const btnUpM =row.querySelector('.upMax');
+  const btnBuy1 = row.querySelector('.buy1');
+  const btnBuyM = row.querySelector('.buyMax');
+  const btnUp1  = row.querySelector('.up1');
+  const btnUpM  = row.querySelector('.upMax');
 
-  
-  
-  // assign colors
   if (btnBuy1) btnBuy1.classList.add('btn','btn-buy');
   if (btnBuyM) btnBuyM.classList.add('btn','btn-buy-agg');
   if (btnUp1)  btnUp1.classList.add('btn','btn-upg');
   if (btnUpM)  btnUpM.classList.add('btn','btn-upg-agg');
 
-  // compute affordability atomically to avoid transient flash
-  const costBuy1 = nextUnitCost(g);
-  const canBuy1  = state.power >= costBuy1;
-
-  const costUp1  = nextUpgradeCost(g);
-  const canUp1   = state.power >= costUp1;
-
-  let needToNext = (10 - ((g.level|0)%10)) % 10;
-  const canUpM = canUp1 && (needToNext > 1 ? (state.power >= costUp1 * needToNext) : canUp1);
-
-  // choose a simple bulk rule for buyMax (at least 2 units with current money)
-  let canBuyM = false;
-  if (canBuy1) {
-    const price1 = costBuy1;
-    const maxN = Math.floor(state.power / price1);
-    canBuyM = maxN >= 2;
-  }
-
-  setBtnState(btnBuy1, canBuy1);
-  setBtnState(btnBuyM, canBuyM);
-  setBtnState(btnUp1,  canUp1);
-  setBtnState(btnUpM,  canUpM);
-if (btnBuy1) btnBuy1.classList.add('btn','btn-buy');
-  if (btnBuyM) btnBuyM.classList.add('btn','btn-buy-agg');
-  if (btnUp1)  btnUp1.classList.add('btn','btn-upg');
-  if (btnUpM)  btnUpM.classList.add('btn','btn-upg-agg');
-const e1a=row.querySelector('.e1a'), e1b=row.querySelector('.e1b'), e1d=row.querySelector('.e1d');
+  const e1a=row.querySelector('.e1a'), e1b=row.querySelector('.e1b'), e1d=row.querySelector('.e1d');
   const t1a=row.querySelector('.t1a'), t1b=row.querySelector('.t1b'), t1d=row.querySelector('.t1d');
   const eMa=row.querySelector('.eMa'), eMb=row.querySelector('.eMb'), eMd=row.querySelector('.eMd');
   const tMa=row.querySelector('.tMa'), tMb=row.querySelector('.tMb'), tMd=row.querySelector('.tMd');
 
   function refresh(){
     ownEl.textContent = fmt(g.count);
-    eachEl.textContent= fmt(powerFor(g));
-    
-    // 購入
-    const nMax=maxAffordableUnits(g,state.power);
-    const sumU=totalCostUnits(g,nMax);
-    btnBuy1.disabled = state.power<nextUnitCost(g);
-    btnBuyM.disabled = (nMax<=0);
-    btnBuy1.textContent = `購入（${fmt(nextUnitCost(g))}）`;
-    btnBuyM.textContent=`まとめ購入 ×${fmt(nMax)}（${fmt(sumU)}）`;
+    eachEl.textContent = fmt(powerFor(g));
 
-    // 強化
-    const up1=nextUpgradeCost(g);
-    const kMax=maxAffordableUpgrades(g,state.power);
-    const sumK=totalCostUpgrades(g,kMax);
-    btnUp1.textContent = `強化＋1（${fmt(nextUpgradeCost(g))}）`;
-    const willHit10 = (((g.level|0) + 1) % 10 === 0);needToNext = (10 - ((g.level|0)%10)) % 10; const cross10 = false;
-    btnUp1.classList.toggle('milestone', willHit10);
-    if (btnUpM) btnUpM.classList.toggle('milestone', cross10);
+    const nMax = maxAffordableUnits(g, state.power);
+    const sumU = totalCostUnits(g, nMax);
+    if (btnBuy1){
+      const price1 = nextUnitCost(g);
+      btnBuy1.disabled = state.power < price1;
+      btnBuy1.textContent = `購入（${fmt(price1)}）`;
+    }
+    if (btnBuyM){
+      btnBuyM.disabled = (nMax<=0);
+      btnBuyM.textContent = `まとめ購入 ×${fmt(nMax)}（${fmt(sumU)}）`;
+    }
 
-    btnUpM.textContent=`まとめ強化 ×${fmt(kMax)}（${fmt(sumK)}）`;
+    const up1 = nextUpgradeCost(g);
+    const kMax = maxAffordableUpgrades(g, state.power);
+    const sumK = totalCostUpgrades(g, kMax);
+    if (btnUp1){
+      btnUp1.disabled = state.power < up1;
+      btnUp1.textContent = `強化＋1（${fmt(up1)}）`;
+      const willHit10 = (((g.level|0) + 1) % 10 === 0);
+      btnUp1.classList.toggle('milestone', willHit10);
+    }
+    if (btnUpM){
+      btnUpM.disabled = (kMax<=0);
+      btnUpM.textContent = `まとめ強化 ×${fmt(kMax)}（${fmt(sumK)}）`;
+      const cross10 = ((g.level|0)%10) + kMax >= 10;
+      btnUpM.classList.toggle('milestone', cross10);
+    }
 
-    // 強化効果（PPSは全体倍率込みで評価）
-    const s1=simulateTotalAfterUpgrade(state,g,1);
+    const s1 = simulateTotalAfterUpgrade(state,g,1);
     e1a.textContent=fmt(s1.beforeEach); e1b.textContent=fmt(s1.afterEach); e1d.textContent=fmt(s1.deltaEach);
     t1a.textContent=fmt(s1.beforeTotal); t1b.textContent=fmt(s1.afterTotal); t1d.textContent=fmt(s1.deltaTotal);
 
-    const sM=simulateTotalAfterUpgrade(state,g,Math.max(kMax,0));
+    const sM = simulateTotalAfterUpgrade(state,g,Math.max(kMax,0));
     eMa.textContent=fmt(sM.beforeEach); eMb.textContent=fmt(sM.afterEach); eMd.textContent=fmt(Math.max(0,sM.deltaEach));
     tMa.textContent=fmt(sM.beforeTotal); tMb.textContent=fmt(sM.afterTotal); tMd.textContent=fmt(Math.max(0,sM.deltaTotal));
+
+    const lvNowEl=row.querySelector('.lvNow');
+    const lvNextEl=row.querySelector('.lvNext');
+    if (lvNowEl) lvNowEl.textContent = String(g.level|0);
+    if (lvNextEl) lvNextEl.textContent = String((g.level|0)+1);
   }
 
-  btnBuy1.addEventListener('click',()=>{if(!btnBuy1.disabled){if(buyUnits(state,g.id,'1'))onUpdate();refresh();}});
-  btnBuyM.addEventListener('click',()=>{if(!btnBuyM.disabled){if(buyUnits(state,g.id,'max'))onUpdate();refresh();}});
-  btnUp1 .addEventListener('click',()=>{if(!btnUp1.disabled ){if(upgrade (state,g.id,'1'))onUpdate();refresh();}});
-  btnUpM .addEventListener('click',()=>{if(!btnUpM.disabled ){if(upgrade (state,g.id,'max'))onUpdate();refresh();}});
+  if (btnBuy1) btnBuy1.addEventListener('click',()=>{ if(!btnBuy1.disabled && buyUnits(state,g.id,'1')){ onUpdate(); refresh(); } });
+  if (btnBuyM) btnBuyM.addEventListener('click',()=>{ if(!btnBuyM.disabled && buyUnits(state,g.id,'max')){ onUpdate(); refresh(); } });
+  if (btnUp1)  btnUp1.addEventListener('click',()=>{ if(!btnUp1.disabled  && upgrade(state,g.id,'1')){ onUpdate(); refresh(); } });
+  if (btnUpM)  btnUpM.addEventListener('click',()=>{ if(!btnUpM.disabled  && upgrade(state,g.id,'max')){ onUpdate(); refresh(); } });
 
   refresh();
   return row;
@@ -200,47 +183,47 @@ export function bindFormatToggle(state){
 
 
 export function lightRefresh(state){
-  
-  // Click block info (Lv and effects) — create once if missing
+  // update click info and buttons
   try{
     const info = document.getElementById('clickInfo');
     if (info && !info.querySelector('.lvNowClick')){
       const wrap = document.createElement('div');
-      wrap.innerHTML = '<div class="desc lvline">Lv <span class="lvNowClick">0</span> → <span class="lvNextClick">1</span></div>'
-        + '<div class="desc upEffect">強化+1効果：クリック <span class="c1a"></span> → <span class="c1b"></span>（+<span class="c1d"></span>）</div>'
-        + '<div class="desc upEffectMax">まとめ強化効果：クリック <span class="cMa"></span> → <span class="cMb"></span>（+<span class="cMd"></span>）</div>';
+      wrap.innerHTML = '<div class="desc lvline">Lv <span class="lvNowClick">0</span> → <span class="lvNextClick">1</span></div>'+
+        '<div class="desc upEffect">強化+1効果：クリック <span class="c1a"></span> → <span class="c1b"></span>（+<span class="c1d"></span>）</div>'+
+        '<div class="desc upEffectMax">まとめ強化効果：クリック <span class="cMa"></span> → <span class="cMb"></span>（+<span class="cMd"></span>）</div>';
       info.appendChild(wrap);
     }
     const lvNow = state.clickLv|0;
-    const lvNext = lvNow+1;
+    const lvNext= lvNow+1;
     const cNow = clickGainByLevel(lvNow);
-    const cNext = clickGainByLevel(lvNext);
-    const kMaxC = maxAffordableClick(state);
-    const cMax  = clickGainByLevel(lvNow + kMaxC);
-    const nEl = document.querySelector('.lvNowClick');
-    const xEl = document.querySelector('.lvNextClick');
-    if(nEl) nEl.textContent = String(lvNow);
-    if(xEl) xEl.textContent = String(lvNext);
+    const cNext= clickGainByLevel(lvNext);
+    const kMaxC= maxAffordableClick(state);
+    const cMax = clickGainByLevel(lvNow + kMaxC);
+    const nEl=document.querySelector('.lvNowClick');
+    const xEl=document.querySelector('.lvNextClick');
+    if(nEl) nEl.textContent=String(lvNow);
+    if(xEl) xEl.textContent=String(lvNext);
     const c1a=document.querySelector('.c1a'), c1b=document.querySelector('.c1b'), c1d=document.querySelector('.c1d');
     const cMa=document.querySelector('.cMa'), cMb=document.querySelector('.cMb'), cMd=document.querySelector('.cMd');
-    if(c1a) c1a.textContent = fmt(cNow);
-    if(c1b) c1b.textContent = fmt(cNext);
-    if(c1d) c1d.textContent = fmt(Math.max(0,cNext-cNow));
-    if(cMa) cMa.textContent = fmt(cNow);
-    if(cMb) cMb.textContent = fmt(cMax);
-    if(cMd) cMd.textContent = fmt(Math.max(0,cMax-cNow));
+    if(c1a) c1a.textContent=fmt(cNow);
+    if(c1b) c1b.textContent=fmt(cNext);
+    if(c1d) c1d.textContent=fmt(Math.max(0,cNext-cNow));
+    if(cMa) cMa.textContent=fmt(cNow);
+    if(cMb) cMb.textContent=fmt(cMax);
+    if(cMd) cMd.textContent=fmt(Math.max(0,cMax-cNow));
   }catch{}
-// クリック強化（最大）
-  const bm = document.getElementById('upgradeClickMax');
-  const b1 = document.getElementById('upgradeClick');
-  if (bm && b1){
+
+  const btn1 = document.getElementById('upgradeClick');
+  const btnM = document.getElementById('upgradeClickMax');
+  if (btn1 && btnM){
     const cost1 = clickNextCost(state.clickLv);
-    b1.disabled = state.power < cost1;
+    btn1.disabled = state.power < cost1;
     const nMax = maxAffordableClick(state);
-    bm.disabled = (nMax <= 0);
-    bm.textContent = `まとめ強化 ×${fmt(nMax)}`;
+    btnM.disabled = (nMax <= 0);
+    btnM.textContent = `まとめ強化 ×${fmt(nMax)}`;
   }
-  // ジェネ各行
+
+  // update generator rows
   const rows = Array.from(document.querySelectorAll('#genlist .gen'));
   rows.forEach((row, idx)=>{
     const g = state.gens[idx];
@@ -249,94 +232,38 @@ export function lightRefresh(state){
     const btnBuyM=row.querySelector('.buyMax');
     const btnUp1 =row.querySelector('.up1');
     const btnUpM =row.querySelector('.upMax');
-    
-  
-  // assign colors
-  if (btnBuy1) btnBuy1.classList.add('btn','btn-buy');
-  if (btnBuyM) btnBuyM.classList.add('btn','btn-buy-agg');
-  if (btnUp1)  btnUp1.classList.add('btn','btn-upg');
-  if (btnUpM)  btnUpM.classList.add('btn','btn-upg-agg');
 
-  // compute affordability atomically to avoid transient flash
-  const costBuy1 = nextUnitCost(g);
-  const canBuy1  = state.power >= costBuy1;
+    const nMax = maxAffordableUnits(g,state.power);
+    const sumU = totalCostUnits(g,nMax);
+    if(btnBuy1){
+      const price1 = nextUnitCost(g);
+      btnBuy1.disabled = state.power < price1;
+      btnBuy1.textContent = `購入（${fmt(price1)}）`;
+    }
+    if(btnBuyM){
+      btnBuyM.disabled = (nMax<=0);
+      btnBuyM.textContent = `まとめ購入 ×${fmt(nMax)}（${fmt(sumU)}）`;
+    }
 
-  const costUp1  = nextUpgradeCost(g);
-  const canUp1   = state.power >= costUp1;needToNext = (10 - ((g.level|0)%10)) % 10;
-  const canUpM = canUp1 && (needToNext > 1 ? (state.power >= costUp1 * needToNext) : canUp1);
+    const up1 = nextUpgradeCost(g);
+    const kMax = maxAffordableUpgrades(g,state.power);
+    const sumK = totalCostUpgrades(g,kMax);
+    if(btnUp1){
+      btnUp1.disabled = state.power < up1;
+      btnUp1.textContent = `強化＋1（${fmt(up1)}）`;
+      const willHit10 = (((g.level|0)+1)%10===0);
+      btnUp1.classList.toggle('milestone', willHit10);
+    }
+    if(btnUpM){
+      btnUpM.disabled = (kMax<=0);
+      btnUpM.textContent = `まとめ強化 ×${fmt(kMax)}（${fmt(sumK)}）`;
+      const cross10 = ((g.level|0)%10) + kMax >= 10;
+      btnUpM.classList.toggle('milestone', cross10);
+    }
 
-  // choose a simple bulk rule for buyMax (at least 2 units with current money)
-  let canBuyM = false;
-  if (canBuy1) {
-    const price1 = costBuy1;
-    const maxN = Math.floor(state.power / price1);
-    canBuyM = maxN >= 2;
-  }
-
-  setBtnState(btnBuy1, canBuy1);
-  setBtnState(btnBuyM, canBuyM);
-  setBtnState(btnUp1,  canUp1);
-  setBtnState(btnUpM,  canUpM);
-if (btnBuy1) btnBuy1.classList.add('btn','btn-buy');
-  if (btnBuyM) btnBuyM.classList.add('btn','btn-buy-agg');
-  if (btnUp1)  btnUp1.classList.add('btn','btn-upg');
-  if (btnUpM)  btnUpM.classList.add('btn','btn-upg-agg');
-if (!(btnBuy1 && btnBuyM && btnUp1 && btnUpM)) return;
-
-    const nMax=maxAffordableUnits(g,state.power);
-    const sumU=totalCostUnits(g,nMax);
-    btnBuy1.disabled = state.power<nextUnitCost(g);
-    btnBuyM.disabled = (nMax<=0);
-    btnBuy1.textContent = `購入（${fmt(nextUnitCost(g))}）`;
-    btnBuyM.textContent = `まとめ購入 ×${fmt(nMax)}（${fmt(sumU)}）`;
-
-    const up1=nextUpgradeCost(g);
-    const kMax=maxAffordableUpgrades(g,state.power);
-    const sumK=totalCostUpgrades(g,kMax);
-    btnUp1.disabled = state.power<up1;
-    btnUpM.disabled = (kMax<=0);
-    btnUp1.textContent = `強化＋1（${fmt(up1)}）`;
-    btnUpM.textContent = `まとめ強化 ×${fmt(kMax)}（${fmt(sumK)}）`;
-
-    const willHit10 = (((g.level|0) + 1) % 10 === 0);needToNext = (10 - ((g.level|0)%10)) % 10; const cross10 = false;
-    btnUp1.classList.toggle('milestone', willHit10);
-    if (btnUpM) btnUpM.classList.toggle('milestone', cross10);
-
-    // 左側 Lv と差分（+1 / 最大）
     const lvNowEl=row.querySelector('.lvNow');
     const lvNextEl=row.querySelector('.lvNext');
     if (lvNowEl) lvNowEl.textContent = String(g.level|0);
     if (lvNextEl) lvNextEl.textContent = String((g.level|0)+1);
-
-    const e1a=row.querySelector('.e1a'), e1b=row.querySelector('.e1b'), e1d=row.querySelector('.e1d');
-    const t1a=row.querySelector('.t1a'), t1b=row.querySelector('.t1b'), t1d=row.querySelector('.t1d');
-    const eMa=row.querySelector('.eMa'), eMb=row.querySelector('.eMb'), eMd=row.querySelector('.eMd');
-    const tMa=row.querySelector('.tMa'), tMb=row.querySelector('.tMb'), tMd=row.querySelector('.tMd');
-
-    try{
-      const curEach = powerFor(g);
-      const nextEach = powerFor({...g, level:(g.level|0)+1});
-      const dEach = Math.max(0, nextEach - curEach);
-      if (e1a) e1a.textContent = fmt(curEach);
-      if (e1b) e1b.textContent = fmt(nextEach);
-      if (e1d) e1d.textContent = fmt(dEach);
-
-      const currTot = (totalPps(state) * globalMultiplier(state.clickLv));
-      const afterTot = (totalPps({...state, gens: state.gens.map(x=> x.id===g.id ? {...g, level:(g.level|0)+1 } : x)}) * globalMultiplier(state.clickLv));
-      if (t1a) t1a.textContent = fmt(currTot);
-      if (t1b) t1b.textContent = fmt(afterTot);
-      if (t1d) t1d.textContent = fmt(Math.max(0, afterTot - currTot));
-
-      const kAfter = (g.level|0)+kMax;
-      const nextEachM = powerFor({...g, level:kAfter});
-      if (eMa) eMa.textContent = fmt(curEach);
-      if (eMb) eMb.textContent = fmt(nextEachM);
-      if (eMd) eMd.textContent = fmt(Math.max(0, nextEachM - curEach));
-
-      const afterTotM = (totalPps({...state, gens: state.gens.map(x=> x.id===g.id ? {...g, level:kAfter } : x)}) * globalMultiplier(state.clickLv));
-      if (tMa) tMa.textContent = fmt(currTot);
-      if (tMb) tMb.textContent = fmt(afterTotM);
-      if (tMd) tMd.textContent = fmt(Math.max(0, afterTotM - currTot));
-    }catch{}
   });
 }

--- a/style.css
+++ b/style.css
@@ -104,7 +104,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.1.15 UI color refinements === */
+/* === 0.1.1.16 UI color refinements === */
 :root{
   --buy:#2a78ff; --buy-deep:#1d56b8;
   --upg:#9b5cff; --upg-deep:#6a39c2;


### PR DESCRIPTION
## Summary
- fix generator bulk upgrade availability and milestone effect
- refresh button states during auto power gain
- revamp number formatting (JP/ENG) and bump version to 0.1.1.16

## Testing
- `node --check js/ui.js`
- `node --input-type=module - <<'NODE'
import {fmt,setFormatMode} from './js/format.js';
setFormatMode('eng');
console.log('eng',fmt(0.00999),fmt(0.0123),fmt(0.0999),fmt(0.1),fmt(99.999),fmt(1000),fmt(12345));
setFormatMode('jp');
console.log('jp',fmt(0.00999),fmt(0.0999),fmt(1),fmt(10000),fmt(1234567890123));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b94a4287008331aba6c5afaad3b998