### PR TITLE
feat: add rebirth feature unlocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magical Clicker Ver.0.1.3.0</title>
+  <title>Magical Clicker Ver.0.1.4.0</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}
@@ -40,7 +40,7 @@
 
       <!-- メイドスマイル強化（位置を分離） -->
       <div class="panel">
-        <div class="hd frill frill-lav"><strong>メイドスマイル強化</strong></div>
+        <div class="hd frill frill-green frill-top"><strong>メイドスマイル強化</strong></div>
         <div class="bd">
           <div class="desc lvline">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
           <div class="desc upEffect">
@@ -58,7 +58,7 @@
 
       <!-- ユニット -->
       <div class="panel">
-          <div class="hd frill frill-mint">
+          <div class="hd frill frill-yellow frill-zigzag">
             <strong>エンジェルメイドユニット</strong>
             <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
           </div>
@@ -70,7 +70,7 @@
 
     <aside class="right">
         <div class="panel">
-          <div class="hd frill frill-pink double"><strong>アイドル覚醒</strong></div>
+          <div class="hd frill frill-pink frill-double"><strong>アイドル覚醒</strong></div>
           <div class="bd">
             <div class="box muted">所持ハートスター：<span id="prestigeCurr">0</span></div>
             <div class="box mt8">次覚醒で獲得：<span id="prestigeGain">0</span>
@@ -81,7 +81,12 @@
         </div>
 
       <div class="panel">
-        <div class="hd frill frill-lav"><strong>システム</strong></div>
+        <div class="hd frill frill-green frill-wave"><strong>転生特典</strong></div>
+        <div class="bd" id="featurePanel"></div>
+      </div>
+
+      <div class="panel">
+        <div class="hd frill frill-yellow frill-wave"><strong>システム</strong></div>
         <div class="bd">
           <div class="row">
             <button id="saveBtn" class="btn good">保存</button>

--- a/js/features.js
+++ b/js/features.js
@@ -1,0 +1,9 @@
+export const FEATURES = [
+  { level:1, id:'autoTap',      name:'オートタップ',         desc:'ONにすると毎秒自動タップします。' },
+  { level:2, id:'burst',        name:'バーストタップ',       desc:'押すとタップの100倍を即時獲得（10秒クールダウン）' },
+  { level:3, id:'autoGen',      name:'自動ユニット購入',     desc:'ONにすると最安ユニットを自動購入します。' },
+  { level:4, id:'convert',      name:'ハートスター変換',     desc:'エンジェルハート1e6をハートスター1に変換します。' },
+  { level:5, id:'hyper',        name:'ハイパーモード',       desc:'30秒間全体倍率10倍（60秒クールダウン）' },
+  { level:6, id:'autoClickUp',  name:'自動スマイル強化',     desc:'ONにするとパワーがある限り自動でスマイル強化します。' },
+  { level:7, id:'surge',        name:'ギャラクシーサージ',   desc:'押すと所持エンジェルハートが一時的に1e6倍（120秒クールダウン）' },
+];

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.3.0 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.4.0 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }

--- a/js/index.html
+++ b/js/index.html
@@ -35,7 +35,7 @@
 
       <!-- メイドスマイル強化（位置を分離） -->
       <div class="panel">
-        <div class="hd frill frill-lav"><strong>メイドスマイル強化</strong></div>
+        <div class="hd frill frill-green frill-top"><strong>メイドスマイル強化</strong></div>
         <div class="bd">
           <div class="row wrap">
             <span class="pill" id="clickLvInfo">Lv 0</span>
@@ -52,7 +52,7 @@
 
       <!-- ジェネレーター -->
         <div class="panel">
-          <div class="hd frill frill-mint">
+          <div class="hd frill frill-yellow frill-zigzag">
             <strong>エンジェルメイドユニット</strong>
             <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
           </div>
@@ -64,7 +64,7 @@
 
     <aside class="right">
         <div class="panel">
-          <div class="hd frill frill-pink double"><strong>アイドル覚醒</strong></div>
+          <div class="hd frill frill-pink frill-double"><strong>アイドル覚醒</strong></div>
           <div class="bd">
             <div class="box muted">所持ハートスター：<span id="prestigeCurr">0</span></div>
             <div class="box mt8">次覚醒で獲得：<span id="prestigeGain">0</span>
@@ -73,9 +73,13 @@
             <div class="rebirths" id="rebirthList"></div>
           </div>
         </div>
+      <div class="panel">
+        <div class="hd frill frill-green frill-wave"><strong>転生特典</strong></div>
+        <div class="bd" id="featurePanel"></div>
+      </div>
 
       <div class="panel">
-        <div class="hd frill frill-lav"><strong>システム</strong></div>
+        <div class="hd frill frill-yellow frill-wave"><strong>システム</strong></div>
         <div class="bd">
           <div class="row">
             <button id="saveBtn" class="btn good">保存</button>

--- a/js/main.js
+++ b/js/main.js
@@ -1,15 +1,25 @@
-export const VERSION = 'Ver.0.1.3.0';
+export const VERSION = 'Ver.0.1.4.0';
 import { GENERATORS } from './data.js';
 import { save, load, reset } from './save.js';
 import { renderAll, renderKPI, lightRefresh, bindFormatToggle } from './ui.js';
 import { clickGainByLevel, clickNextCost, globalMultiplier, clickTotalCost, maxAffordableClicks } from './click.js';
-import { prestigeGain } from './prestige.js';
+import { prestigeGain, REBIRTHS, rebirthMultiplier } from './prestige.js';
+import { totalPps, nextUnitCost, buyUnits } from './economy.js';
 
 const state = {
   power: 0,
   clickLv: 0,
   gens: JSON.parse(JSON.stringify(GENERATORS)),
   prestige: 0,
+  rebirth: 0,
+  autoTap:false,
+  burstCooldown:0,
+  autoGen:false,
+  hyperActive:false,
+  hyperCooldown:0,
+  hyperTime:0,
+  autoClickUp:false,
+  surgeCooldown:0,
 };
 
 // Restore
@@ -18,17 +28,51 @@ if (saved){
   state.power = saved.power ?? 0;
   state.clickLv = saved.clickLv ?? 0;
   state.prestige = saved.prestige ?? 0;
+  state.rebirth = saved.rebirth ?? 0;
   if (Array.isArray(saved.gens)){
     state.gens = saved.gens;
   }
 }
 
+const featureHandlers = {
+  toggleAutoTap(){ state.autoTap = !state.autoTap; update(); },
+  doBurst(){
+    if(state.burstCooldown>0) return;
+    const mult = rebirthMultiplier(state.rebirth) * (state.hyperActive?10:1);
+    state.power += clickGainByLevel(state.clickLv) * mult * 100;
+    state.burstCooldown = 10;
+    update();
+  },
+  toggleAutoGen(){ state.autoGen = !state.autoGen; update(); },
+  convertPrestige(){
+    if(state.power < 1e6) return alert('エンジェルハートが足りません');
+    state.power -= 1e6;
+    state.prestige += 1;
+    update();
+  },
+  activateHyper(){
+    if(state.hyperCooldown>0) return;
+    state.hyperActive = true;
+    state.hyperTime = 30;
+    state.hyperCooldown = 60;
+    update();
+  },
+  toggleAutoClickUp(){ state.autoClickUp = !state.autoClickUp; update(); },
+  activateSurge(){
+    if(state.surgeCooldown>0) return;
+    state.power *= 1e6;
+    state.surgeCooldown = 120;
+    update();
+  }
+};
+
 function update(){
-  renderAll(state);
+  renderAll(state, performRebirth, featureHandlers);
 }
 
 document.getElementById('tapBtn').addEventListener('click', ()=>{
-  state.power += clickGainByLevel(state.clickLv);
+  const mult = rebirthMultiplier(state.rebirth) * (state.hyperActive?10:1);
+  state.power += clickGainByLevel(state.clickLv) * mult;
   update();
 });
 
@@ -54,13 +98,15 @@ document.getElementById('upgradeClickMax').addEventListener('click', ()=>{
 document.getElementById('saveBtn').addEventListener('click', ()=>{ save(state); alert('保存しました'); });
 document.getElementById('loadBtn').addEventListener('click', ()=>{
   const s = load(); if (!s) return alert('保存がありません');
-  state.power = s.power ?? 0; state.clickLv = s.clickLv ?? 0; state.prestige = s.prestige ?? 0; state.gens = Array.isArray(s.gens)? s.gens: state.gens;
+  state.power = s.power ?? 0; state.clickLv = s.clickLv ?? 0; state.prestige = s.prestige ?? 0; state.rebirth = s.rebirth ?? 0; state.gens = Array.isArray(s.gens)? s.gens: state.gens;
+  state.autoTap=false; state.burstCooldown=0; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
   update(); alert('読込しました');
 });
 document.getElementById('resetBtn').addEventListener('click', ()=>{
   if (!confirm('ハードリセットしますか？')) return;
   reset();
-  state.power=0; state.clickLv=0; state.prestige=0; state.gens = JSON.parse(JSON.stringify(GENERATORS));
+  state.power=0; state.clickLv=0; state.prestige=0; state.rebirth=0; state.gens = JSON.parse(JSON.stringify(GENERATORS));
+  state.autoTap=false; state.burstCooldown=0; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
   update();
 });
 
@@ -78,10 +124,7 @@ document.getElementById('prestigeBtn').addEventListener('click', ()=>{
 // initial render
 update();
 try{ const v=document.getElementById('version'); if(v) v.textContent = VERSION; }catch{}
-try{ bindFormatToggle && bindFormatToggle(state); }catch{}
-
-
-import { totalPps } from './economy.js';
+try{ bindFormatToggle && bindFormatToggle(state, featureHandlers); }catch{}
 
 let __lastTs = 0;
 let __sinceUI = 0;
@@ -90,15 +133,58 @@ function __loop(ts){
   const dt = Math.max(0, (ts-__lastTs)/1000);
   __lastTs = ts;
   try{
-    const pps = totalPps(state) * globalMultiplier(state.clickLv);
+    const mult = rebirthMultiplier(state.rebirth) * (state.hyperActive?10:1);
+    const pps = totalPps(state) * globalMultiplier(state.clickLv) * mult;
     if (Number.isFinite(pps) && pps>0) { state.power += pps * dt; }
+    if(state.autoTap){
+      state.power += clickGainByLevel(state.clickLv) * mult * dt;
+    }
+    if(state.autoGen){
+      const g = state.gens[0];
+      const price = nextUnitCost(g);
+      if(state.power >= price) buyUnits(state,'g1','1');
+    }
+    if(state.autoClickUp){
+      const cost = clickNextCost(state.clickLv);
+      if(state.power >= cost){ state.power -= cost; state.clickLv += 1; }
+    }
+    if(state.hyperActive){
+      state.hyperTime -= dt;
+      if(state.hyperTime <= 0) state.hyperActive=false;
+    }
+    if(state.hyperCooldown>0) state.hyperCooldown -= dt;
+    if(state.burstCooldown>0) state.burstCooldown -= dt;
+    if(state.surgeCooldown>0) state.surgeCooldown -= dt;
+
     renderKPI(state);
     __sinceUI += dt;
-    if (__sinceUI >= 0.1){ lightRefresh(state); __sinceUI = 0; }
+    if (__sinceUI >= 0.1){ lightRefresh(state, performRebirth, featureHandlers); __sinceUI = 0; }
   }catch{}
   requestAnimationFrame(__loop);
 }
 requestAnimationFrame(__loop);
 
 
-try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.3.0'; }catch(e){}
+try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.4.0'; }catch(e){}
+
+function flashRebirth(){
+  try{
+    document.body.classList.add('rebirth-flash');
+    setTimeout(()=>document.body.classList.remove('rebirth-flash'),1000);
+  }catch{}
+}
+
+function performRebirth(){
+  const next = REBIRTHS[state.rebirth];
+  if(!next) return alert('これ以上の転生はありません');
+  if(state.prestige < next.req) return alert('転生にはもっとハートスターが必要です');
+  if(!confirm(`L${next.level} ${next.name} に転生しますか？`)) return;
+  state.rebirth += 1;
+  state.prestige = 0;
+  state.power = 0;
+  state.clickLv = 0;
+  state.gens = JSON.parse(JSON.stringify(GENERATORS));
+  state.autoTap=false; state.burstCooldown=0; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
+  flashRebirth();
+  update();
+}

--- a/js/prestige.js
+++ b/js/prestige.js
@@ -1,14 +1,21 @@
 export const REBIRTHS = [
-  { level:1, name:'マジカルメイド・シュガースプラッシュ', req:'エンジェルハート 1e6', effect:'タップ倍率+10%' },
-  { level:2, name:'マジカルエンジェル・プリズムドレス', req:'ハートスター 10', effect:'全体倍率+5%' },
-  { level:3, name:'マジカルアイドル・メルティシンフォニー', req:'ハートスター 25', effect:'ユニット性能+10%' },
-  { level:4, name:'メイドスターリーループ', req:'ハートスター 50', effect:'コスト-5%' },
-  { level:5, name:'エンジェリックブロッサムウィング', req:'ハートスター 100', effect:'タップ倍率+25%' },
-  { level:6, name:'アイドルセレナーデステージ', req:'ハートスター 250', effect:'全体倍率+15%' },
-  { level:7, name:'エターナルレインボーハーモニー', req:'ハートスター 500', effect:'全ステータス+20%' },
+  { level:1, name:'マジカルメイド・シュガースプラッシュ', req:10,  effect:'全体倍率×1e3',   feature:'オートタップが解禁（ボタンでON/OFF）' },
+  { level:2, name:'マジカルエンジェル・プリズムドレス',   req:1e3, effect:'全体倍率×1e6',   feature:'バーストタップが解禁（ボタンを押すと100倍タップ）' },
+  { level:3, name:'マジカルアイドル・メルティシンフォニー', req:1e6, effect:'全体倍率×1e12',  feature:'自動ユニット購入が解禁（ボタンでON/OFF）' },
+  { level:4, name:'メイドスターリーループ',                 req:1e9,  effect:'全体倍率×1e24',  feature:'ハートスター変換が解禁（ボタンで変換）' },
+  { level:5, name:'エンジェリックブロッサムウィング',       req:1e12, effect:'全体倍率×1e48',  feature:'ハイパーモードが解禁（ボタンで発動）' },
+  { level:6, name:'アイドルセレナーデステージ',               req:1e15, effect:'全体倍率×1e96',  feature:'自動スマイル強化が解禁（ボタンでON/OFF）' },
+  { level:7, name:'エターナルレインボーハーモニー',           req:1e18, effect:'全体倍率×1e192', feature:'ギャラクシーサージが解禁（ボタンで1e6倍）' },
 ];
 
 export function prestigeGain(power){
   if (power < 1e6) return 0;
   return Math.floor(Math.sqrt(power / 1e6));
 }
+
+const MULTIPLIERS = [1, 1e3, 1e6, 1e12, 1e24, 1e48, 1e96, 1e192];
+
+export function rebirthMultiplier(level){
+  return MULTIPLIERS[level] || 1;
+}
+

--- a/js/style.css
+++ b/js/style.css
@@ -96,7 +96,12 @@ body{
 .rebirths{ display:flex; flex-direction:column; gap:12px }
 .rebirth-item{ display:flex; flex-direction:column; gap:4px }
 .rebirth-item .cond{ font-size:18px }
+.rebirth-item .feat{ font-size:18px }
 
+
+/* ====== Feature panel ====== */
+#featurePanel .feature-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
+#featurePanel .feature-item .desc{ font-size:18px; color:#c6c0ea }
 
 /* ====== Misc ====== */
 .box{ border:1px solid #2c2950; border-radius:12px; padding:14px; background:rgba(255,255,255,.02) }
@@ -110,23 +115,25 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.3.0 UI color refinements === */
+/* === 0.1.4.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;
   --frill-pink:#ffbde4;
-  --frill-lav:#d6ccff;
-  --frill-mint:#c7f5cf;
+  --frill-green:#c7f5cf;
+  --frill-yellow:#fff5b3;
   --mint:#a7f3d0;
 }
 .btn-buy{background:linear-gradient(180deg,var(--buy) 0%,var(--buy-deep) 100%);color:#fff;}
 .btn-buy-agg{background:linear-gradient(180deg,var(--buy-deep) 0%,#a6008c 100%);color:#fff;}
 .btn-upg{background:linear-gradient(180deg,var(--upg) 0%,var(--upg-deep) 100%);color:#fff;}
 .btn-upg-agg{background:linear-gradient(180deg,var(--upg-deep) 0%,#4b1a99 100%);color:#fff;}
+
 .hd.frill{position:relative; --frill-color:var(--frill-pink);}
-.hd.frill.frill-lav{--frill-color:var(--frill-lav);}
-.hd.frill.frill-mint{--frill-color:var(--frill-mint);}
 .hd.frill.frill-pink{--frill-color:var(--frill-pink);}
+.hd.frill.frill-green{--frill-color:var(--frill-green);}
+.hd.frill.frill-yellow{--frill-color:var(--frill-yellow);}
+
 .hd.frill::after{
   content:'';
   position:absolute;
@@ -135,11 +142,47 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
   background:radial-gradient(circle at 8px 0,var(--frill-color) 8px,transparent 8px) repeat-x;
   background-size:16px 8px;
 }
-.hd.frill.double::before{
+
+.hd.frill.frill-top::after{
+  top:-6px; bottom:auto;
+  background:radial-gradient(circle at 8px 100%,var(--frill-color) 8px,transparent 8px) repeat-x;
+  background-size:16px 8px;
+}
+
+.hd.frill.frill-double::before{
   content:'';
   position:absolute;
   left:0; right:0; top:-6px;
   height:6px;
   background:radial-gradient(circle at 8px 100%,var(--frill-color) 8px,transparent 8px) repeat-x;
   background-size:16px 8px;
+}
+
+.hd.frill.frill-zigzag::after{
+  bottom:-6px;
+  height:6px;
+  background:
+    linear-gradient(-45deg,var(--frill-color) 4px,transparent 0) 0 0/8px 8px repeat-x,
+    linear-gradient(45deg,var(--frill-color) 4px,transparent 0) 4px 0/8px 8px repeat-x;
+}
+
+.hd.frill.frill-wave::after{
+  bottom:-6px;
+  height:6px;
+  background:radial-gradient(50% 50% at 8px 6px,var(--frill-color) 8px,transparent 8px) repeat-x;
+  background-size:16px 8px;
+}
+
+body.rebirth-flash::before{
+  content:'';
+  position:fixed;
+  inset:0;
+  background:radial-gradient(circle, rgba(255,245,179,.9), rgba(255,189,228,.4), transparent 70%);
+  animation:rebirthFlash 1s ease-out forwards;
+  pointer-events:none;
+  z-index:9999;
+}
+@keyframes rebirthFlash{
+  from{opacity:1;}
+  to{opacity:0;}
 }

--- a/style.css
+++ b/style.css
@@ -96,7 +96,12 @@ body{
 .rebirths{ display:flex; flex-direction:column; gap:12px }
 .rebirth-item{ display:flex; flex-direction:column; gap:4px }
 .rebirth-item .cond{ font-size:18px }
+.rebirth-item .feat{ font-size:18px }
 
+
+/* ====== Feature panel ====== */
+#featurePanel .feature-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
+#featurePanel .feature-item .desc{ font-size:18px; color:#c6c0ea }
 
 /* ====== Misc ====== */
 .box{ border:1px solid #2c2950; border-radius:12px; padding:14px; background:rgba(255,255,255,.02) }
@@ -110,13 +115,13 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.3.0 UI color refinements === */
+/* === 0.1.4.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;
   --frill-pink:#ffbde4;
-  --frill-lav:#d6ccff;
-  --frill-mint:#c7f5cf;
+  --frill-green:#c7f5cf;
+  --frill-yellow:#fff5b3;
   --mint:#a7f3d0;
 }
 .btn-buy{background:linear-gradient(180deg,var(--buy) 0%,var(--buy-deep) 100%);color:#fff;}
@@ -125,9 +130,10 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 .btn-upg-agg{background:linear-gradient(180deg,var(--upg-deep) 0%,#4b1a99 100%);color:#fff;}
 
 .hd.frill{position:relative; --frill-color:var(--frill-pink);}
-.hd.frill.frill-lav{--frill-color:var(--frill-lav);}
-.hd.frill.frill-mint{--frill-color:var(--frill-mint);}
 .hd.frill.frill-pink{--frill-color:var(--frill-pink);}
+.hd.frill.frill-green{--frill-color:var(--frill-green);}
+.hd.frill.frill-yellow{--frill-color:var(--frill-yellow);}
+
 .hd.frill::after{
   content:'';
   position:absolute;
@@ -136,11 +142,47 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
   background:radial-gradient(circle at 8px 0,var(--frill-color) 8px,transparent 8px) repeat-x;
   background-size:16px 8px;
 }
-.hd.frill.double::before{
+
+.hd.frill.frill-top::after{
+  top:-6px; bottom:auto;
+  background:radial-gradient(circle at 8px 100%,var(--frill-color) 8px,transparent 8px) repeat-x;
+  background-size:16px 8px;
+}
+
+.hd.frill.frill-double::before{
   content:'';
   position:absolute;
   left:0; right:0; top:-6px;
   height:6px;
   background:radial-gradient(circle at 8px 100%,var(--frill-color) 8px,transparent 8px) repeat-x;
   background-size:16px 8px;
+}
+
+.hd.frill.frill-zigzag::after{
+  bottom:-6px;
+  height:6px;
+  background:
+    linear-gradient(-45deg,var(--frill-color) 4px,transparent 0) 0 0/8px 8px repeat-x,
+    linear-gradient(45deg,var(--frill-color) 4px,transparent 0) 4px 0/8px 8px repeat-x;
+}
+
+.hd.frill.frill-wave::after{
+  bottom:-6px;
+  height:6px;
+  background:radial-gradient(50% 50% at 8px 6px,var(--frill-color) 8px,transparent 8px) repeat-x;
+  background-size:16px 8px;
+}
+
+body.rebirth-flash::before{
+  content:'';
+  position:fixed;
+  inset:0;
+  background:radial-gradient(circle, rgba(255,245,179,.9), rgba(255,189,228,.4), transparent 70%);
+  animation:rebirthFlash 1s ease-out forwards;
+  pointer-events:none;
+  z-index:9999;
+}
+@keyframes rebirthFlash{
+  from{opacity:1;}
+  to{opacity:0;}
 }


### PR DESCRIPTION
## Summary
- Restore original rebirth tier names while keeping inflated costs and multipliers
- Unlock a new gameplay feature at each rebirth tier and display controls in a dedicated panel
- Document each tier's added feature in the rebirth list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98fea5b348331b36ad36d66098d03