### PR TITLE
Fix Decimal finite check in formatter

### DIFF
--- a/js/format.js
+++ b/js/format.js
@@ -5,7 +5,9 @@ export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; 
 export function getFormatMode(){ return __mode; }
 export function fmt(x){
   if (typeof Decimal !== 'undefined' && x instanceof Decimal){
-    if (!x.isFinite()) return x.toString();
+    // Break Infinity's Decimal lacks an isFinite() method. Inspect the raw
+    // mantissa/exponent to detect non-finite values before converting.
+    if (!Number.isFinite(x.exponent) || !Number.isFinite(x.mantissa)) return x.toString();
     if (x.exponent >= 308) return x.toString();
     x = x.toNumber();
   }


### PR DESCRIPTION
## Summary
- avoid calling missing `isFinite` on Break Infinity `Decimal` by checking mantissa/exponent directly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9aeef2b848331abcfea6e3f68379d