### PR TITLE
style: arrange generators in column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magical Clicker Ver.0.1.4.0</title>
+  <title>Magical Clicker Ver.0.1.5.0</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}
@@ -20,7 +20,7 @@
       <button id="fmtToggle" class="btn small">表記：日本式</button>
     </header>
 
-    <div class="col main">
+    <div class="col left">
       <!-- タップ（ハートを獲得する場所） -->
       <div class="panel">
         <div class="hd frill frill-pink"><strong>エンジェルハートタップ</strong><span class="muted">（タップでエンジェルハートを獲得）</span></div>
@@ -55,16 +55,16 @@
           </div>
         </div>
       </div>
+    </div>
 
-      <!-- ユニット -->
-      <div class="panel">
-          <div class="hd frill frill-yellow frill-zigzag">
-            <strong>エンジェルメイドユニット</strong>
-            <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
-          </div>
-        <div class="bd">
-          <div class="genlist" id="genlist"></div>
+    <!-- ユニット -->
+    <div class="panel genpanel">
+        <div class="hd frill frill-yellow frill-zigzag">
+          <strong>エンジェルメイドユニット</strong>
+          <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
         </div>
+      <div class="bd">
+        <div class="genlist" id="genlist"></div>
       </div>
     </div>
 
@@ -79,6 +79,11 @@
             <div class="rebirths" id="rebirthList"></div>
           </div>
         </div>
+
+      <div class="panel">
+        <div class="hd frill frill-green frill-wave"><strong>転職</strong></div>
+        <div class="bd" id="jobPanel"></div>
+      </div>
 
       <div class="panel">
         <div class="hd frill frill-green frill-wave"><strong>転生特典</strong></div>

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.4.0 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.5.0 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }

--- a/js/jobs.js
+++ b/js/jobs.js
@@ -1,0 +1,11 @@
+export const JOBS = [
+  { id:'magical', name:'魔法少女', tap:2, gen:1, prestige:1, desc:'タップに特化し獲得ハート2倍' },
+  { id:'maid',    name:'メイド',    tap:1, gen:2, prestige:1, desc:'ユニット性能に特化しPPS2倍' },
+  { id:'angel',   name:'天使',     tap:1, gen:1, prestige:2, desc:'覚醒ハートスター獲得2倍' },
+  { id:'idol',    name:'アイドル',  tap:1.5, gen:1.5, prestige:1.5, desc:'総合力型で全て1.5倍' },
+];
+
+export function getJobBonuses(id){
+  const j = JOBS.find(j=>j.id===id);
+  return j ? { tap:j.tap, gen:j.gen, prestige:j.prestige } : { tap:1, gen:1, prestige:1 };
+}

--- a/js/style.css
+++ b/js/style.css
@@ -10,9 +10,9 @@ body{
 }
 .container{
   max-width:1400px; margin:24px auto; padding:0 20px;
-  display:grid; grid-template-columns:1.6fr .9fr; gap:20px;
+  display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px;
 }
-.title{ grid-column:1 / span 2; display:flex; align-items:center; gap:14px }
+.title{ grid-column:1 / span 3; display:flex; align-items:center; gap:14px }
 .title h1{ margin:0; font-size:32px; font-weight:800 }
 .badge{ font-size:16px; color:#bdb7e7; background:rgba(255,255,255,.06); padding:4px 10px; border-radius:999px; border:1px solid #2c2950 }
 .spacer{ flex:1 }
@@ -32,7 +32,9 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
-.right{ display:flex; flex-direction:column; gap:12px; min-width:320px }
+.left{ grid-column:1; }
+.genpanel{ grid-column:1 / span 2; }
+.right{ grid-column:3; grid-row:2 / span 2; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -84,7 +86,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:flex; flex-direction:column; gap:14px }
+.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px }
 .gen{
   display:grid; grid-template-columns:1fr 420px; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -102,6 +104,8 @@ body{
 /* ====== Feature panel ====== */
 #featurePanel .feature-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
 #featurePanel .feature-item .desc{ font-size:18px; color:#c6c0ea }
+#jobPanel .job-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
+#jobPanel .job-item .desc{ font-size:18px; color:#c6c0ea }
 
 /* ====== Misc ====== */
 .box{ border:1px solid #2c2950; border-radius:12px; padding:14px; background:rgba(255,255,255,.02) }
@@ -111,11 +115,13 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 @media (max-width: 1100px){
   .container{ grid-template-columns:1fr; }
   .gen{ grid-template-columns:1fr; }
-  .right{ min-width:0 }
+  .genpanel{ grid-column:1; }
+  .genlist{ grid-template-columns:1fr; }
+  .right{ grid-column:1; grid-row:auto; min-width:0 }
 }
 
 
-/* === 0.1.4.0 UI color refinements === */
+/* === 0.1.5.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;

--- a/style.css
+++ b/style.css
@@ -10,9 +10,9 @@ body{
 }
 .container{
   max-width:1400px; margin:24px auto; padding:0 20px;
-  display:grid; grid-template-columns:1.6fr .9fr; gap:20px;
+  display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px;
 }
-.title{ grid-column:1 / span 2; display:flex; align-items:center; gap:14px }
+.title{ grid-column:1 / span 3; display:flex; align-items:center; gap:14px }
 .title h1{ margin:0; font-size:32px; font-weight:800 }
 .badge{ font-size:16px; color:#bdb7e7; background:rgba(255,255,255,.06); padding:4px 10px; border-radius:999px; border:1px solid #2c2950 }
 .spacer{ flex:1 }
@@ -32,7 +32,9 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
-.right{ display:flex; flex-direction:column; gap:12px; min-width:320px }
+.left{ grid-column:1; }
+.genpanel{ grid-column:1 / span 2; }
+.right{ grid-column:3; grid-row:2 / span 2; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -84,7 +86,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:flex; flex-direction:column; gap:14px }
+.genlist{ display:grid; grid-auto-flow:column; grid-template-columns:1fr 1fr; grid-template-rows:repeat(5,auto); gap:14px }
 .gen{
   display:grid; grid-template-columns:1fr 420px; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -102,6 +104,8 @@ body{
 /* ====== Feature panel ====== */
 #featurePanel .feature-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
 #featurePanel .feature-item .desc{ font-size:18px; color:#c6c0ea }
+#jobPanel .job-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
+#jobPanel .job-item .desc{ font-size:18px; color:#c6c0ea }
 
 /* ====== Misc ====== */
 .box{ border:1px solid #2c2950; border-radius:12px; padding:14px; background:rgba(255,255,255,.02) }
@@ -111,11 +115,13 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 @media (max-width: 1100px){
   .container{ grid-template-columns:1fr; }
   .gen{ grid-template-columns:1fr; }
-  .right{ min-width:0 }
+  .genpanel{ grid-column:1; }
+  .genlist{ grid-auto-flow:row; grid-template-columns:1fr; grid-template-rows:none; }
+  .right{ grid-column:1; grid-row:auto; min-width:0 }
 }
 
 
-/* === 0.1.4.0 UI color refinements === */
+/* === 0.1.5.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;


### PR DESCRIPTION
## Summary
- display generators column-first to keep lists balanced
- reset generator grid to a single column on narrow screens

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bacf193d6083318e74045d35502c6d