### PR TITLE
Refine layout and job system for v0.1.5.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magical Clicker Ver.0.1.5.0</title>
+  <title>Magical Clicker Ver.0.1.5.1</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}
@@ -19,6 +19,17 @@
       <div class="spacer"></div>
       <button id="fmtToggle" class="btn small">表記：日本式</button>
     </header>
+
+    <!-- ユニット -->
+    <div class="panel genpanel">
+        <div class="hd frill frill-yellow frill-zigzag">
+          <strong>エンジェルメイドユニット</strong>
+          <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
+        </div>
+      <div class="bd">
+        <div class="genlist" id="genlist"></div>
+      </div>
+    </div>
 
     <div class="col left">
       <!-- タップ（ハートを獲得する場所） -->
@@ -54,17 +65,6 @@
             <button id="upgradeClickMax" class="btn up alt">まとめ強化 ×0</button>
           </div>
         </div>
-      </div>
-    </div>
-
-    <!-- ユニット -->
-    <div class="panel genpanel">
-        <div class="hd frill frill-yellow frill-zigzag">
-          <strong>エンジェルメイドユニット</strong>
-          <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
-        </div>
-      <div class="bd">
-        <div class="genlist" id="genlist"></div>
       </div>
     </div>
 

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.5.0 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.5.1 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }

--- a/js/jobs.js
+++ b/js/jobs.js
@@ -1,11 +1,35 @@
 export const JOBS = [
-  { id:'magical', name:'魔法少女', tap:2, gen:1, prestige:1, desc:'タップに特化し獲得ハート2倍' },
-  { id:'maid',    name:'メイド',    tap:1, gen:2, prestige:1, desc:'ユニット性能に特化しPPS2倍' },
-  { id:'angel',   name:'天使',     tap:1, gen:1, prestige:2, desc:'覚醒ハートスター獲得2倍' },
-  { id:'idol',    name:'アイドル',  tap:1.5, gen:1.5, prestige:1.5, desc:'総合力型で全て1.5倍' },
+  // 魔法少女系
+  { id:'magical',   name:'魔法少女',   tap:2,   gen:1,   prestige:1,   desc:'タップに特化し獲得ハート2倍',            point:'時間片' },
+  { id:'mage',      name:'魔導師',     tap:2.5, gen:1.1, prestige:1,   desc:'魔法の研鑽でタップ2.5倍',                point:'時間片' },
+  { id:'archmage',  name:'大魔導師',   tap:3,   gen:1.2, prestige:1.1, desc:'大魔力でタップ3倍',                      point:'時間片' },
+  { id:'timemage',  name:'時空魔導師', tap:3.5, gen:1.3, prestige:1.2, desc:'時空魔法でタップ3.5倍',                  point:'時間片' },
+  { id:'chrono',    name:'クロノマンサー', tap:4,   gen:1.4, prestige:1.3, desc:'時間を操りタップ効率4倍',                 point:'時間片' },
+
+  // メイド系
+  { id:'maid',        name:'メイド',     tap:1,   gen:2,   prestige:1,   desc:'ユニット性能に特化しPPS2倍',              point:'賢者石片' },
+  { id:'headmaid',    name:'メイド長',   tap:1.1, gen:2.5, prestige:1,   desc:'指揮でPPS2.5倍',                        point:'賢者石片' },
+  { id:'royalmaid',   name:'宮廷メイド', tap:1.2, gen:3,   prestige:1.1, desc:'宮廷仕込みでPPS3倍',                    point:'賢者石片' },
+  { id:'alchemymaid', name:'錬金メイド', tap:1.3, gen:3.5, prestige:1.2, desc:'錬金術でPPS3.5倍',                      point:'賢者石片' },
+  { id:'alchemist',   name:'アルケミスト', tap:1.4, gen:4,   prestige:1.3, desc:'錬金術でPPS4倍',                         point:'賢者石片' },
+
+  // 天使系
+  { id:'angel',     name:'天使',     tap:1,   gen:1,   prestige:2,   desc:'覚醒ハートスター獲得2倍',              point:'天啓' },
+  { id:'archangel', name:'大天使',   tap:1.1, gen:1.1, prestige:2.5, desc:'更なる加護で2.5倍',                    point:'天啓' },
+  { id:'throne',    name:'座天使',   tap:1.2, gen:1.2, prestige:3,   desc:'神の座に仕える',                        point:'天啓' },
+  { id:'dominion',  name:'主天使',   tap:1.3, gen:1.3, prestige:3.5, desc:'支配を司る',                            point:'天啓' },
+  { id:'seraph',    name:'熾天使',   tap:1.4, gen:1.4, prestige:4,   desc:'天界の加護で覚醒ハートスター獲得4倍',   point:'天啓' },
+
+  // アイドル系
+  { id:'idol',       name:'アイドル',     tap:1.5, gen:1.5, prestige:1.5, desc:'総合力型で全て1.5倍',                point:'スターオーラ' },
+  { id:'popstar',    name:'人気アイドル', tap:1.6, gen:1.6, prestige:1.6, desc:'人気で全て1.6倍',                    point:'スターオーラ' },
+  { id:'superstar',  name:'スーパースター', tap:1.7, gen:1.7, prestige:1.7, desc:'スターの力で全て1.7倍',                point:'スターオーラ' },
+  { id:'galaxyidol', name:'銀河アイドル', tap:1.8, gen:1.8, prestige:1.8, desc:'銀河規模で全て1.8倍',                  point:'スターオーラ' },
+  { id:'diva',       name:'次元アイドル', tap:1.9, gen:1.9, prestige:1.9, desc:'異次元の人気で全て1.9倍',              point:'スターオーラ' },
 ];
 
 export function getJobBonuses(id){
   const j = JOBS.find(j=>j.id===id);
   return j ? { tap:j.tap, gen:j.gen, prestige:j.prestige } : { tap:1, gen:1, prestige:1 };
 }
+

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-export const VERSION = 'Ver.0.1.5.0';
+export const VERSION = 'Ver.0.1.5.1';
 import { GENERATORS } from './data.js';
 import { getJobBonuses } from './jobs.js';
 import { save, load, reset } from './save.js';
@@ -22,6 +22,7 @@ const state = {
   autoClickUp:false,
   surgeCooldown:0,
   job:'magical',
+  jobPoints:{},
 };
 
 function applyGenBoost(){
@@ -47,6 +48,7 @@ if (saved){
   state.rebirth = saved.rebirth ?? 0;
   state.genRebirths = saved.genRebirths ?? 0;
   state.job = saved.job || 'magical';
+  state.jobPoints = saved.jobPoints || {};
   if (Array.isArray(saved.gens)){
     state.gens = saved.gens;
   }
@@ -82,7 +84,11 @@ const featureHandlers = {
     state.surgeCooldown = 120;
     update();
   },
-  changeJob(id){ state.job = id; update(); }
+  changeJob(id){
+    state.job = id;
+    state.jobPoints[id] = (state.jobPoints[id]||0) + 1;
+    update();
+  }
 };
 
 function update(){
@@ -118,9 +124,10 @@ document.getElementById('upgradeClickMax').addEventListener('click', ()=>{
 document.getElementById('saveBtn').addEventListener('click', ()=>{ save(state); alert('保存しました'); });
 document.getElementById('loadBtn').addEventListener('click', ()=>{
   const s = load(); if (!s) return alert('保存がありません');
-  state.power = s.power ? new Decimal(s.power) : new Decimal(0);
-  state.clickLv = s.clickLv ?? 0; state.prestige = s.prestige ?? 0; state.rebirth = s.rebirth ?? 0; state.genRebirths = s.genRebirths ?? 0; state.job = s.job || 'magical';
-  state.gens = Array.isArray(s.gens)? s.gens: state.gens;
+    state.power = s.power ? new Decimal(s.power) : new Decimal(0);
+    state.clickLv = s.clickLv ?? 0; state.prestige = s.prestige ?? 0; state.rebirth = s.rebirth ?? 0; state.genRebirths = s.genRebirths ?? 0; state.job = s.job || 'magical';
+    state.jobPoints = s.jobPoints || {};
+    state.gens = Array.isArray(s.gens)? s.gens: state.gens;
   applyGenBoost();
   state.autoTap=false; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
   update(); alert('読込しました');
@@ -128,7 +135,7 @@ document.getElementById('loadBtn').addEventListener('click', ()=>{
 document.getElementById('resetBtn').addEventListener('click', ()=>{
   if (!confirm('ハードリセットしますか？')) return;
   reset();
-  state.power=new Decimal(0); state.clickLv=0; state.prestige=0; state.rebirth=0; state.genRebirths=0; state.job='magical'; state.gens = JSON.parse(JSON.stringify(GENERATORS));
+    state.power=new Decimal(0); state.clickLv=0; state.prestige=0; state.rebirth=0; state.genRebirths=0; state.job='magical'; state.jobPoints={}; state.gens = JSON.parse(JSON.stringify(GENERATORS));
   applyGenBoost();
   state.autoTap=false; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
   update();
@@ -190,7 +197,7 @@ function __loop(ts){
 requestAnimationFrame(__loop);
 
 
-try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.5.0'; }catch(e){}
+try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.5.1'; }catch(e){}
 
 function flashRebirth(){
   try{

--- a/js/style.css
+++ b/js/style.css
@@ -32,9 +32,9 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
-.left{ grid-column:1; }
+.left{ grid-column:3; }
 .genpanel{ grid-column:1 / span 2; }
-.right{ grid-column:3; grid-row:2 / span 2; display:flex; flex-direction:column; gap:12px; min-width:320px }
+.right{ grid-column:3; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -86,7 +86,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px }
+.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px; grid-auto-flow:column }
 .gen{
   display:grid; grid-template-columns:1fr 420px; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -116,12 +116,13 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
   .container{ grid-template-columns:1fr; }
   .gen{ grid-template-columns:1fr; }
   .genpanel{ grid-column:1; }
-  .genlist{ grid-template-columns:1fr; }
+  .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
+  .left{ grid-column:1; }
   .right{ grid-column:1; grid-row:auto; min-width:0 }
 }
 
 
-/* === 0.1.5.0 UI color refinements === */
+/* === 0.1.5.1 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;

--- a/js/ui.js
+++ b/js/ui.js
@@ -174,6 +174,11 @@ export function renderJobs(state, onChange){
     d.className='desc';
     d.textContent = j.desc;
     item.appendChild(d);
+    const p=document.createElement('div');
+    p.className='desc';
+    const pts = state.jobPoints && state.jobPoints[j.id] ? state.jobPoints[j.id] : 0;
+    p.textContent = `特殊ポイント：${j.point} ${pts}`;
+    item.appendChild(p);
     panel.appendChild(item);
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magical-clicker",
-  "version": "1.0.0",
+  "version": "0.1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "magical-clicker",
-      "version": "1.0.0",
+      "version": "0.1.5.1",
       "license": "ISC",
       "dependencies": {
         "break_infinity.js": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-clicker",
-  "version": "1.0.0",
+  "version": "0.1.5.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -32,9 +32,9 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
-.left{ grid-column:1; }
+.left{ grid-column:3; }
 .genpanel{ grid-column:1 / span 2; }
-.right{ grid-column:3; grid-row:2 / span 2; display:flex; flex-direction:column; gap:12px; min-width:320px }
+.right{ grid-column:3; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -86,7 +86,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px }
+.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px; grid-auto-flow:column }
 .gen{
   display:grid; grid-template-columns:1fr 420px; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -116,12 +116,13 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
   .container{ grid-template-columns:1fr; }
   .gen{ grid-template-columns:1fr; }
   .genpanel{ grid-column:1; }
-  .genlist{ grid-template-columns:1fr; }
+  .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
+  .left{ grid-column:1; }
   .right{ grid-column:1; grid-row:auto; min-width:0 }
 }
 
 
-/* === 0.1.5.0 UI color refinements === */
+/* === 0.1.5.1 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;


### PR DESCRIPTION
## Summary
- Expand each profession into a five-tier path, keeping original names and adding advanced classes
- Default and reset jobs start at the base 魔法少女 tier

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb955b42888331b636e4034a5682d9