### PR TITLE
Improve job selection and fix generator layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magical Clicker Ver.0.1.5.1</title>
+   <title>Magical Clicker Ver.0.1.6.0</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.5.1 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.6.0 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }

--- a/js/jobs.js
+++ b/js/jobs.js
@@ -1,35 +1,59 @@
-export const JOBS = [
-  // 魔法少女系
-  { id:'magical',   name:'魔法少女',   tap:2,   gen:1,   prestige:1,   desc:'タップに特化し獲得ハート2倍',            point:'時間片' },
-  { id:'mage',      name:'魔導師',     tap:2.5, gen:1.1, prestige:1,   desc:'魔法の研鑽でタップ2.5倍',                point:'時間片' },
-  { id:'archmage',  name:'大魔導師',   tap:3,   gen:1.2, prestige:1.1, desc:'大魔力でタップ3倍',                      point:'時間片' },
-  { id:'timemage',  name:'時空魔導師', tap:3.5, gen:1.3, prestige:1.2, desc:'時空魔法でタップ3.5倍',                  point:'時間片' },
-  { id:'chrono',    name:'クロノマンサー', tap:4,   gen:1.4, prestige:1.3, desc:'時間を操りタップ効率4倍',                 point:'時間片' },
-
-  // メイド系
-  { id:'maid',        name:'メイド',     tap:1,   gen:2,   prestige:1,   desc:'ユニット性能に特化しPPS2倍',              point:'賢者石片' },
-  { id:'headmaid',    name:'メイド長',   tap:1.1, gen:2.5, prestige:1,   desc:'指揮でPPS2.5倍',                        point:'賢者石片' },
-  { id:'royalmaid',   name:'宮廷メイド', tap:1.2, gen:3,   prestige:1.1, desc:'宮廷仕込みでPPS3倍',                    point:'賢者石片' },
-  { id:'alchemymaid', name:'錬金メイド', tap:1.3, gen:3.5, prestige:1.2, desc:'錬金術でPPS3.5倍',                      point:'賢者石片' },
-  { id:'alchemist',   name:'アルケミスト', tap:1.4, gen:4,   prestige:1.3, desc:'錬金術でPPS4倍',                         point:'賢者石片' },
-
-  // 天使系
-  { id:'angel',     name:'天使',     tap:1,   gen:1,   prestige:2,   desc:'覚醒ハートスター獲得2倍',              point:'天啓' },
-  { id:'archangel', name:'大天使',   tap:1.1, gen:1.1, prestige:2.5, desc:'更なる加護で2.5倍',                    point:'天啓' },
-  { id:'throne',    name:'座天使',   tap:1.2, gen:1.2, prestige:3,   desc:'神の座に仕える',                        point:'天啓' },
-  { id:'dominion',  name:'主天使',   tap:1.3, gen:1.3, prestige:3.5, desc:'支配を司る',                            point:'天啓' },
-  { id:'seraph',    name:'熾天使',   tap:1.4, gen:1.4, prestige:4,   desc:'天界の加護で覚醒ハートスター獲得4倍',   point:'天啓' },
-
-  // アイドル系
-  { id:'idol',       name:'アイドル',     tap:1.5, gen:1.5, prestige:1.5, desc:'総合力型で全て1.5倍',                point:'スターオーラ' },
-  { id:'popstar',    name:'人気アイドル', tap:1.6, gen:1.6, prestige:1.6, desc:'人気で全て1.6倍',                    point:'スターオーラ' },
-  { id:'superstar',  name:'スーパースター', tap:1.7, gen:1.7, prestige:1.7, desc:'スターの力で全て1.7倍',                point:'スターオーラ' },
-  { id:'galaxyidol', name:'銀河アイドル', tap:1.8, gen:1.8, prestige:1.8, desc:'銀河規模で全て1.8倍',                  point:'スターオーラ' },
-  { id:'diva',       name:'次元アイドル', tap:1.9, gen:1.9, prestige:1.9, desc:'異次元の人気で全て1.9倍',              point:'スターオーラ' },
+export const JOB_GROUPS = [
+  {
+    id: 'magic',
+    name: '魔導師系',
+    jobs: [
+      { id:'mage',      name:'魔導師',     tap:2,   gen:1.1, prestige:1,   desc:'魔法の研鑽でタップ2倍',                point:'時間片' },
+      { id:'archmage',  name:'大魔導師',   tap:2.5, gen:1.2, prestige:1.1, desc:'大魔力でタップ2.5倍',                  point:'時間片' },
+      { id:'timemage',  name:'時空魔導師', tap:3,   gen:1.3, prestige:1.2, desc:'時空魔法でタップ3倍',                  point:'時間片' },
+      { id:'chrono',    name:'クロノマンサー', tap:3.5, gen:1.4, prestige:1.3, desc:'時間を操りタップ効率3.5倍', point:'時間片' },
+      { id:'timelord',  name:'タイムロード',   tap:4,   gen:1.5, prestige:1.4, desc:'時間を支配しタップ4倍', point:'時間片' },
+    ],
+  },
+  {
+    id: 'maid',
+    name: 'メイド系',
+    jobs: [
+      { id:'maid',        name:'メイド',     tap:1,   gen:2,   prestige:1,   desc:'ユニット性能に特化しPPS2倍',          point:'賢者石片' },
+      { id:'headmaid',    name:'メイド長',   tap:1.1, gen:2.5, prestige:1,   desc:'指揮でPPS2.5倍',                        point:'賢者石片' },
+      { id:'royalmaid',   name:'宮廷メイド', tap:1.2, gen:3,   prestige:1.1, desc:'宮廷仕込みでPPS3倍',                    point:'賢者石片' },
+      { id:'alchemymaid', name:'錬金メイド', tap:1.3, gen:3.5, prestige:1.2, desc:'錬金術でPPS3.5倍',                      point:'賢者石片' },
+      { id:'alchemist',   name:'アルケミスト', tap:1.4, gen:4,   prestige:1.3, desc:'錬金術でPPS4倍',                          point:'賢者石片' },
+    ],
+  },
+  {
+    id: 'angel',
+    name: '天使系',
+    jobs: [
+      { id:'angel',     name:'天使',     tap:1,   gen:1,   prestige:2,   desc:'覚醒ハートスター獲得2倍',              point:'天啓' },
+      { id:'archangel', name:'大天使',   tap:1.1, gen:1.1, prestige:2.5, desc:'更なる加護で2.5倍',                    point:'天啓' },
+      { id:'throne',    name:'座天使',   tap:1.2, gen:1.2, prestige:3,   desc:'神の座に仕える',                        point:'天啓' },
+      { id:'dominion',  name:'主天使',   tap:1.3, gen:1.3, prestige:3.5, desc:'支配を司る',                            point:'天啓' },
+      { id:'seraph',    name:'熾天使',   tap:1.4, gen:1.4, prestige:4,   desc:'天界の加護で覚醒ハートスター獲得4倍',   point:'天啓' },
+    ],
+  },
+  {
+    id: 'idol',
+    name: 'アイドル系',
+    jobs: [
+      { id:'idol',       name:'アイドル',     tap:1.5, gen:1.5, prestige:1.5, desc:'総合力型で全て1.5倍',                point:'スターオーラ' },
+      { id:'popstar',    name:'人気アイドル', tap:1.6, gen:1.6, prestige:1.6, desc:'人気で全て1.6倍',                    point:'スターオーラ' },
+      { id:'superstar',  name:'スーパースター', tap:1.7, gen:1.7, prestige:1.7, desc:'スターの力で全て1.7倍', point:'スターオーラ' },
+      { id:'galaxyidol', name:'銀河アイドル', tap:1.8, gen:1.8, prestige:1.8, desc:'銀河規模で全て1.8倍',                  point:'スターオーラ' },
+      { id:'diva',       name:'次元アイドル', tap:1.9, gen:1.9, prestige:1.9, desc:'異次元の人気で全て1.9倍',              point:'スターオーラ' },
+    ],
+  },
 ];
 
+export const JOBS = [
+  { id:'magical', name:'魔法少女', tap:1, gen:1, prestige:1, desc:'まだ何の力も持たない魔法少女', point:'なし' },
+  ...JOB_GROUPS.flatMap(g => g.jobs),
+];
+
+const JOB_MAP = Object.fromEntries(JOBS.map(j => [j.id, j]));
+
 export function getJobBonuses(id){
-  const j = JOBS.find(j=>j.id===id);
+  const j = JOB_MAP[id];
   return j ? { tap:j.tap, gen:j.gen, prestige:j.prestige } : { tap:1, gen:1, prestige:1 };
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-export const VERSION = 'Ver.0.1.5.1';
+export const VERSION = 'Ver.0.1.6.0';
 import { GENERATORS } from './data.js';
 import { getJobBonuses } from './jobs.js';
 import { save, load, reset } from './save.js';
@@ -23,6 +23,7 @@ const state = {
   surgeCooldown:0,
   job:'magical',
   jobPoints:{},
+  jobCat:'magic',
 };
 
 function applyGenBoost(){
@@ -49,6 +50,7 @@ if (saved){
   state.genRebirths = saved.genRebirths ?? 0;
   state.job = saved.job || 'magical';
   state.jobPoints = saved.jobPoints || {};
+  state.jobCat = saved.jobCat || 'magic';
   if (Array.isArray(saved.gens)){
     state.gens = saved.gens;
   }
@@ -127,6 +129,7 @@ document.getElementById('loadBtn').addEventListener('click', ()=>{
     state.power = s.power ? new Decimal(s.power) : new Decimal(0);
     state.clickLv = s.clickLv ?? 0; state.prestige = s.prestige ?? 0; state.rebirth = s.rebirth ?? 0; state.genRebirths = s.genRebirths ?? 0; state.job = s.job || 'magical';
     state.jobPoints = s.jobPoints || {};
+    state.jobCat = s.jobCat || 'magic';
     state.gens = Array.isArray(s.gens)? s.gens: state.gens;
   applyGenBoost();
   state.autoTap=false; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
@@ -136,6 +139,7 @@ document.getElementById('resetBtn').addEventListener('click', ()=>{
   if (!confirm('ハードリセットしますか？')) return;
   reset();
     state.power=new Decimal(0); state.clickLv=0; state.prestige=0; state.rebirth=0; state.genRebirths=0; state.job='magical'; state.jobPoints={}; state.gens = JSON.parse(JSON.stringify(GENERATORS));
+  state.jobCat='magic';
   applyGenBoost();
   state.autoTap=false; state.autoGen=false; state.hyperActive=false; state.hyperCooldown=0; state.hyperTime=0; state.autoClickUp=false; state.surgeCooldown=0;
   update();
@@ -197,7 +201,7 @@ function __loop(ts){
 requestAnimationFrame(__loop);
 
 
-try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.5.1'; }catch(e){}
+try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.6.0'; }catch(e){}
 
 function flashRebirth(){
   try{

--- a/js/style.css
+++ b/js/style.css
@@ -86,7 +86,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px; grid-auto-flow:column }
+.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px; grid-auto-flow:row }
 .gen{
   display:grid; grid-template-columns:1fr 420px; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -122,7 +122,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.5.1 UI color refinements === */
+/* === 0.1.6.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,6 +1,6 @@
 function setBtnState(btn, enabled){ if(!btn) return; btn.disabled=!enabled; btn.classList.toggle('is-disabled', !enabled); }
 import { fmt, getFormatMode, setFormatMode } from './format.js';
-import { JOBS, getJobBonuses } from './jobs.js';
+import { JOBS, JOB_GROUPS, getJobBonuses } from './jobs.js';
 import { clickGainByLevel, clickNextCost, globalMultiplier, clickTotalCost, maxAffordableClicks } from './click.js';
 import {
   nextUnitCost, totalCostUnits, maxAffordableUnits, buyUnits,
@@ -162,7 +162,27 @@ export function renderJobs(state, onChange){
   const panel=document.getElementById('jobPanel');
   if(!panel) return;
   panel.innerHTML='';
-  JOBS.forEach(j=>{
+
+  const base = JOBS.find(j=>j.id==='magical');
+  if(base){
+    panel.appendChild(makeItem(base));
+  }
+
+  const catRow=document.createElement('div');
+  catRow.className='row';
+  JOB_GROUPS.forEach(cat=>{
+    const b=document.createElement('button');
+    b.className = state.jobCat===cat.id ? 'btn good' : 'btn';
+    b.textContent = cat.name;
+    b.addEventListener('click', ()=>{ state.jobCat = cat.id; renderJobs(state, onChange); });
+    catRow.appendChild(b);
+  });
+  panel.appendChild(catRow);
+
+  const group = JOB_GROUPS.find(c=>c.id===state.jobCat) || JOB_GROUPS[0];
+  group.jobs.forEach(j=> panel.appendChild(makeItem(j)));
+
+  function makeItem(j){
     const item=document.createElement('div');
     item.className='job-item';
     const btn=document.createElement('button');
@@ -179,8 +199,8 @@ export function renderJobs(state, onChange){
     const pts = state.jobPoints && state.jobPoints[j.id] ? state.jobPoints[j.id] : 0;
     p.textContent = `特殊ポイント：${j.point} ${pts}`;
     item.appendChild(p);
-    panel.appendChild(item);
-  });
+    return item;
+  }
 }
 
 /* ===== ジェネ ===== */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magical-clicker",
-  "version": "0.1.5.1",
+  "version": "0.1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "magical-clicker",
-      "version": "0.1.5.1",
+    "name": "magical-clicker",
+    "version": "0.1.6.0",
       "license": "ISC",
       "dependencies": {
         "break_infinity.js": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-clicker",
-  "version": "0.1.5.1",
+  "version": "0.1.6.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -86,7 +86,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px; grid-auto-flow:column }
+.genlist{ display:grid; grid-template-columns:1fr 1fr; gap:14px; grid-auto-flow:row }
 .gen{
   display:grid; grid-template-columns:1fr 420px; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -122,7 +122,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.5.1 UI color refinements === */
+/* === 0.1.6.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;


### PR DESCRIPTION
## Summary
- fix generator grid layout so generators render correctly
- group jobs into four categories with starter job having no bonuses
- add fifth tier to magic jobs for full progression
- bump version to 0.1.6.0

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bbab15b4448331a81481b404851391