### PR TITLE
Adjust layout for click and generator sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,18 +20,7 @@
       <button id="fmtToggle" class="btn small">表記：日本式</button>
     </header>
 
-    <!-- ユニット -->
-    <div class="panel genpanel">
-        <div class="hd frill frill-yellow frill-zigzag">
-          <strong>エンジェルメイドユニット</strong>
-          <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
-        </div>
-      <div class="bd">
-        <div class="genlist" id="genlist"></div>
-      </div>
-    </div>
-
-    <div class="col left">
+      <div class="col left">
       <!-- タップ（ハートを獲得する場所） -->
       <div class="panel">
         <div class="hd frill frill-pink"><strong>エンジェルハートタップ</strong><span class="muted">（タップでエンジェルハートを獲得）</span></div>
@@ -68,7 +57,7 @@
       </div>
     </div>
 
-    <aside class="right">
+      <aside class="right">
         <div class="panel">
           <div class="hd frill frill-pink frill-double"><strong>アイドル覚醒</strong></div>
           <div class="bd">
@@ -100,10 +89,20 @@
           </div>
         </div>
       </div>
-    </aside>
+      </aside>
 
-    
-  </div>
+      <!-- ユニット -->
+      <div class="panel genpanel">
+          <div class="hd frill frill-yellow frill-zigzag">
+            <strong>エンジェルメイドユニット</strong>
+            <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
+          </div>
+        <div class="bd">
+          <div class="genlist" id="genlist"></div>
+        </div>
+      </div>
+
+    </div>
 
   <script src="./js/break_infinity.min.js"></script>
   <script type="module" src="./js/main.js"></script>

--- a/style.css
+++ b/style.css
@@ -32,9 +32,9 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
-.left{ grid-column:1 / span 2; grid-row:3; }
-.genpanel{ grid-column:1 / span 2; }
-.right{ grid-column:3; grid-row:2; display:flex; flex-direction:column; gap:12px; min-width:320px }
+.left{ grid-column:1 / span 2; }
+.genpanel{ grid-column:1 / span 3; }
+.right{ grid-column:3; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -106,6 +106,7 @@ body{
 #featurePanel .feature-item .desc{ font-size:18px; color:#c6c0ea }
 #jobPanel .job-item{ display:flex; flex-direction:column; gap:4px; margin-bottom:12px }
 #jobPanel .job-item .desc{ font-size:18px; color:#c6c0ea }
+#jobPanel .row{ gap:12px; margin-bottom:12px }
 
 /* ====== Misc ====== */
 .box{ border:1px solid #2c2950; border-radius:12px; padding:14px; background:rgba(255,255,255,.02) }


### PR DESCRIPTION
## Summary
- Reorder layout so click/tap controls appear above generators
- Expand generator panel to span entire width
- Add spacing to job selection buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb239dee083319b8f6f7b2e324c79