### PR TITLE
Refine click layout and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <button id="fmtToggle" class="btn small">表記：日本式</button>
     </header>
 
-      <div class="col left">
+      <div class="left clickgrid">
       <!-- タップ（ハートを獲得する場所） -->
       <div class="panel">
         <div class="hd frill frill-pink"><strong>エンジェルハートタップ</strong><span class="muted">（タップでエンジェルハートを獲得）</span></div>

--- a/js/style.css
+++ b/js/style.css
@@ -10,7 +10,8 @@ body{
 }
 .container{
   max-width:2380px; margin:24px auto; padding:0 20px;
-  display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px;
+  display:grid; grid-template-columns:1fr 1fr 1fr;
+  column-gap:20px; row-gap:12px;
 }
 .title{ grid-column:1 / span 3; display:flex; align-items:center; gap:14px }
 .title h1{ margin:0; font-size:32px; font-weight:800 }
@@ -32,6 +33,7 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
+.clickgrid{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
 .left{ grid-column:1 / span 2; grid-row:3; }
 .genpanel{ grid-column:1 / span 2; }
 .right{ grid-column:3; grid-row:2; display:flex; flex-direction:column; gap:12px; min-width:320px }
@@ -118,6 +120,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
   .container{ grid-template-columns:1fr; }
   .genpanel{ grid-column:1; }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
+  .clickgrid{ grid-template-columns:1fr }
   .left{ grid-column:1; grid-row:auto; }
   .right{ grid-column:1; grid-row:auto; min-width:0 }
 }

--- a/style.css
+++ b/style.css
@@ -10,7 +10,8 @@ body{
 }
 .container{
   max-width:2380px; margin:24px auto; padding:0 20px;
-  display:grid; grid-template-columns:1fr 1fr 1fr; gap:20px;
+  display:grid; grid-template-columns:1fr 1fr 1fr;
+  column-gap:20px; row-gap:12px;
   grid-template-areas:
     "title title title"
     "left left right"
@@ -36,6 +37,7 @@ body{
 
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
+.clickgrid{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
 .left{ grid-area:left; }
 .genpanel{ grid-area:genpanel; }
 .right{ grid-area:right; display:flex; flex-direction:column; gap:12px; min-width:320px }
@@ -128,6 +130,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
       "right"
       "genpanel";
   }
+  .clickgrid{ grid-template-columns:1fr }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
   .right{ min-width:0 }
 }


### PR DESCRIPTION
## Summary
- Display tap and click upgrade panels in a single grid to shrink vertical space
- Reduce vertical gap between click area and generator grid
- Update legacy stylesheet to match new layout

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdd61e1648331af03a75691325788