### PR TITLE
タップ関連レイアウトの整理とジェネレーター位置調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <button id="fmtToggle" class="btn small">表記：日本式</button>
     </header>
 
-      <div class="left clickgrid">
+      <div class="tapgrid clickgrid">
       <!-- タップ（ハートを獲得する場所） -->
       <div class="panel">
         <div class="hd frill frill-pink"><strong>エンジェルハートタップ</strong><span class="muted">（タップでエンジェルハートを獲得）</span></div>

--- a/style.css
+++ b/style.css
@@ -14,8 +14,8 @@ body{
   column-gap:12px; row-gap:8px;
   grid-template-areas:
     "title title title"
-    "genpanel genpanel right"
-    "left left right";
+    "tap tap right"
+    "genpanel genpanel right";
 }
 .title{ grid-area:title; display:flex; align-items:center; gap:14px }
 .title h1{ margin:0; font-size:32px; font-weight:800 }
@@ -38,7 +38,7 @@ body{
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
 .clickgrid{ display:grid; grid-template-columns:1fr; gap:8px }
-.left{ grid-area:left; }
+.tapgrid{ grid-area:tap; }
 .genpanel{ grid-area:genpanel; }
 .right{ grid-area:right; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
@@ -133,8 +133,8 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
     grid-template-columns:1fr;
     grid-template-areas:
       "title"
+      "tap"
       "genpanel"
-      "left"
       "right";
   }
   .clickgrid{ grid-template-columns:1fr }


### PR DESCRIPTION
## 概要
- タップ関連のパネルを単一グリッドにまとめ、ジェネレーターの上に配置
- レスポンシブレイアウトを同様に調整

## テスト
- `npm test`（テスト未定義のためエラーを確認）

------
https://chatgpt.com/codex/tasks/task_e_68bbef9238848331afac7b491aac0192