### PR TITLE
タップ強化の統合とジェネレータ配置調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,27 +35,34 @@
               <button id="tapBtn" class="btn tapbtn">ハートタップ！</button>
             </div>
           </div>
-        </div>
-      </div>
-
-      <!-- メイドスマイル強化（位置を分離） -->
-      <div class="panel">
-        <div class="hd frill frill-green frill-top"><strong>メイドスマイル強化</strong></div>
-        <div class="bd">
-          <div class="desc lvline">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
-          <div class="desc upEffect">
-            強化+1効果：スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）｜全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
-          </div>
-          <div class="desc upEffectMax">
-            まとめ強化効果：スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）｜全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
-          </div>
-          <div class="row center mt12">
-            <button id="upgradeClick" class="btn up">単体強化</button>
-            <button id="upgradeClickMax" class="btn up alt">まとめ強化 ×0</button>
+          <div class="mt12">
+            <div class="hd frill frill-green frill-top"><strong>メイドスマイル強化</strong></div>
+            <div class="desc lvline">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
+            <div class="desc upEffect">
+              強化+1効果：スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）｜全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
+            </div>
+            <div class="desc upEffectMax">
+              まとめ強化効果：スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）｜全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
+            </div>
+            <div class="row center mt12">
+              <button id="upgradeClick" class="btn up">単体強化</button>
+              <button id="upgradeClickMax" class="btn up alt">まとめ強化 ×0</button>
+            </div>
           </div>
         </div>
       </div>
     </div>
+
+      <!-- ユニット -->
+      <div class="panel genpanel">
+          <div class="hd frill frill-yellow frill-zigzag">
+            <strong>エンジェルメイドユニット</strong>
+            <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
+          </div>
+        <div class="bd">
+          <div class="genlist" id="genlist"></div>
+        </div>
+      </div>
 
       <aside class="right">
         <div class="panel">
@@ -90,18 +97,6 @@
         </div>
       </div>
       </aside>
-
-      <!-- ユニット -->
-      <div class="panel genpanel">
-          <div class="hd frill frill-yellow frill-zigzag">
-            <strong>エンジェルメイドユニット</strong>
-            <span class="muted">購入＝ピンク系、強化＝ラベンダー系。無効時は灰色で反応なし。</span>
-          </div>
-        <div class="bd">
-          <div class="genlist" id="genlist"></div>
-        </div>
-      </div>
-
     </div>
 
   <script src="./js/break_infinity.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -8,15 +8,15 @@ body{
   font-family:system-ui,-apple-system,'Segoe UI',Roboto,'Noto Sans JP',sans-serif;
   font-size:22px; line-height:1.45;
 }
-.container{
-  max-width:2380px; margin:12px auto; padding:0 10px;
-  display:grid; grid-template-columns:1fr 1fr 1fr;
-  column-gap:12px; row-gap:8px;
-  grid-template-areas:
-    "title title title"
-    "tap tap right"
-    "genpanel genpanel right";
-}
+  .container{
+    max-width:2380px; margin:12px auto; padding:0 10px;
+    display:grid; grid-template-columns:2fr 1fr;
+    column-gap:12px; row-gap:8px;
+    grid-template-areas:
+      "title title"
+      "tap right"
+      "genpanel right";
+  }
 .title{ grid-area:title; display:flex; align-items:center; gap:14px }
 .title h1{ margin:0; font-size:32px; font-weight:800 }
 .badge{ font-size:16px; color:#bdb7e7; background:rgba(255,255,255,.06); padding:4px 10px; border-radius:999px; border:1px solid #2c2950 }


### PR DESCRIPTION
## 概要
- タップパネル内にメイドスマイル強化を統合
- ジェネレーターをタップパネルの下に配置

## テスト
- `npm test` (失敗: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bbfab654588331b354c61c630fda26