### PR TITLE
学者系スキル見直しと上位職条件の統一

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-   <title>Magical Clicker Ver.0.1.7.0</title>
+   <title>Magical Clicker Ver.0.1.8.0</title>
   <link rel="stylesheet" href="./style.css">
   <style>
     .milestone{outline:2px solid gold;box-shadow:0 0 10px rgba(255,215,0,.7);}

--- a/js/format.js
+++ b/js/format.js
@@ -1,4 +1,4 @@
-/* format.js — Ver.0.1.7.0 日本式/ENGフォーマット */
+/* format.js — Ver.0.1.8.0 日本式/ENGフォーマット */
 
 let __mode = 'jp';
 export function setFormatMode(mode){ if(mode==='jp'||mode==='eng') __mode=mode; }

--- a/js/jobs.js
+++ b/js/jobs.js
@@ -3,57 +3,57 @@ export const JOB_GROUPS = [
     id: 'magic',
     name: '魔法少女系',
     jobs: [
-      { id:'kirameki',       name:'きらめき魔法少女', tap:1.5, gen:1.5, prestige:1.5, desc:'きらめきで全て1.5倍',       point:'時間片', req:1e6,    reqType:'power' },
-      { id:'sugarwitch',     name:'シュガーウィッチ', tap:1.6, gen:1.6, prestige:1.6, desc:'甘い魔力で全て1.6倍',       point:'時間片', req:10,      reqType:'point' },
-      { id:'lunamage',       name:'ルナメイジ',       tap:1.7, gen:1.7, prestige:1.7, desc:'月の魔力で全て1.7倍',       point:'時間片', req:100,     reqType:'point' },
-      { id:'whitesorceress', name:'ホワイトソーサレス', tap:1.8, gen:1.8, prestige:1.8, desc:'白き魔法で全て1.8倍',       point:'時間片', req:1000,    reqType:'point' },
-      { id:'mysticsaber',    name:'ミスティックセイバー', tap:1.9, gen:1.9, prestige:1.9, desc:'秘剣で全て1.9倍',         point:'時間片', req:10000,   reqType:'point' },
+      { id:'kirameki',       name:'きらめき魔法少女', tap:1.5, gen:1.5, prestige:1.5, desc:'きらめきで全て1.5倍',       point:'魔導水晶', req:1e6,    reqType:'power' },
+      { id:'sugarwitch',     name:'シュガーウィッチ', tap:1.6, gen:1.6, prestige:1.6, desc:'甘い魔力で全て1.6倍',       point:'魔導水晶', req:100,      reqType:'point' },
+      { id:'lunamage',       name:'ルナメイジ',       tap:1.7, gen:1.7, prestige:1.7, desc:'月の魔力で全て1.7倍',       point:'魔導水晶', req:1000,     reqType:'point' },
+      { id:'whitesorceress', name:'ホワイトソーサレス', tap:1.8, gen:1.8, prestige:1.8, desc:'白き魔法で全て1.8倍',       point:'魔導水晶', req:10000,    reqType:'point' },
+      { id:'mysticsaber',    name:'ミスティックセイバー', tap:1.9, gen:1.9, prestige:1.9, desc:'秘剣で全て1.9倍',         point:'魔導水晶', req:100000,   reqType:'point' },
     ],
   },
   {
     id: 'maid',
     name: 'メイド系',
     jobs: [
-      { id:'lilymaid',      name:'リリィメイド',           tap:1,   gen:2,   prestige:1,   desc:'ユニット性能に特化しPPS2倍',          point:'賢者石片', req:1e6,    reqType:'power' },
-      { id:'sweethouse',    name:'スイートハウスメイド',   tap:1.1, gen:2.5, prestige:1,   desc:'甘いおもてなしでPPS2.5倍',             point:'賢者石片', req:20,      reqType:'point' },
-      { id:'elegantparlor', name:'エレガントパーラーメイド', tap:1.2, gen:3,   prestige:1.1, desc:'優雅な所作でPPS3倍',                    point:'賢者石片', req:200,     reqType:'point' },
-      { id:'graceladies',   name:'グレイスレディズメイド', tap:1.3, gen:3.5, prestige:1.2, desc:'気品でPPS3.5倍',                        point:'賢者石片', req:2000,    reqType:'point' },
-      { id:'royalchief',    name:'ロイヤルチーフメイド',   tap:1.4, gen:4,   prestige:1.3, desc:'王宮仕込みでPPS4倍',                    point:'賢者石片', req:20000,   reqType:'point' },
+      { id:'lilymaid',      name:'リリィメイド',           tap:1,   gen:2,   prestige:1,   desc:'ユニット性能に特化しPPS2倍',          point:'メイドバッジ', req:1e6,    reqType:'power' },
+      { id:'sweethouse',    name:'スイートハウスメイド',   tap:1.1, gen:2.5, prestige:1,   desc:'甘いおもてなしでPPS2.5倍',             point:'メイドバッジ', req:100,      reqType:'point' },
+      { id:'elegantparlor', name:'エレガントパーラーメイド', tap:1.2, gen:3,   prestige:1.1, desc:'優雅な所作でPPS3倍',                    point:'メイドバッジ', req:1000,     reqType:'point' },
+      { id:'graceladies',   name:'グレイスレディズメイド', tap:1.3, gen:3.5, prestige:1.2, desc:'気品でPPS3.5倍',                        point:'メイドバッジ', req:10000,    reqType:'point' },
+      { id:'royalchief',    name:'ロイヤルチーフメイド',   tap:1.4, gen:4,   prestige:1.3, desc:'王宮仕込みでPPS4倍',                    point:'メイドバッジ', req:100000,   reqType:'point' },
     ],
   },
   {
     id: 'angel',
     name: '天使系',
     jobs: [
-      { id:'feathergirl',   name:'フェザーガール',       tap:1,   gen:1,   prestige:2,   desc:'羽の加護で覚醒スタークリスタル獲得2倍', point:'天啓', req:1e6,    reqType:'power' },
-      { id:'breezeangel',   name:'ブリーズエンジェル',   tap:1.1, gen:1.1, prestige:2.5, desc:'そよ風の祝福で2.5倍',                   point:'天啓', req:50,      reqType:'point' },
-      { id:'wingmaiden',    name:'ウィングメイデン',     tap:1.2, gen:1.2, prestige:3,   desc:'翼の導きで3倍',                         point:'天啓', req:500,     reqType:'point' },
-      { id:'celestiamuse',  name:'セレスティアミューズ', tap:1.3, gen:1.3, prestige:3.5, desc:'天上の調べで3.5倍',                     point:'天啓', req:5000,    reqType:'point' },
-      { id:'luminusseraphy',name:'ルミナスセラフィー',   tap:1.4, gen:1.4, prestige:4,   desc:'聖光の加護で覚醒スタークリスタル獲得4倍', point:'天啓', req:50000,   reqType:'point' },
+      { id:'feathergirl',   name:'フェザーガール',       tap:1,   gen:1,   prestige:2,   desc:'羽の加護で覚醒スタークリスタル獲得2倍', point:'聖羽', req:1e6,    reqType:'power' },
+      { id:'breezeangel',   name:'ブリーズエンジェル',   tap:1.1, gen:1.1, prestige:2.5, desc:'そよ風の祝福で2.5倍',                   point:'聖羽', req:100,      reqType:'point' },
+      { id:'wingmaiden',    name:'ウィングメイデン',     tap:1.2, gen:1.2, prestige:3,   desc:'翼の導きで3倍',                         point:'聖羽', req:1000,     reqType:'point' },
+      { id:'celestiamuse',  name:'セレスティアミューズ', tap:1.3, gen:1.3, prestige:3.5, desc:'天上の調べで3.5倍',                     point:'聖羽', req:10000,    reqType:'point' },
+      { id:'luminusseraphy',name:'ルミナスセラフィー',   tap:1.4, gen:1.4, prestige:4,   desc:'聖光の加護で覚醒スタークリスタル獲得4倍', point:'聖羽', req:100000,   reqType:'point' },
     ],
   },
   {
     id: 'idol',
     name: 'アイドル系',
     jobs: [
-      { id:'kyunidol',      name:'きゅんきゅんアイドル', tap:2,   gen:1.1, prestige:1,   desc:'ときめきでタップ2倍',                    point:'スターオーラ', req:1e6,    reqType:'power' },
-      { id:'melodysinger',  name:'メロディシンガー',     tap:2.5, gen:1.2, prestige:1.1, desc:'歌声でタップ2.5倍',                      point:'スターオーラ', req:30,      reqType:'point' },
-      { id:'stagecinderella', name:'ステージシンデレラ', tap:3,   gen:1.3, prestige:1.2, desc:'舞台の輝きでタップ3倍',                 point:'スターオーラ', req:300,     reqType:'point' },
-      { id:'shinystar',     name:'シャイニースター',     tap:3.5, gen:1.4, prestige:1.3, desc:'星の煌めきでタップ3.5倍',               point:'スターオーラ', req:3000,    reqType:'point' },
-      { id:'gloriousdiva',  name:'グロリアスディーヴァ', tap:4,   gen:1.5, prestige:1.4, desc:'栄光のステージでタップ4倍',             point:'スターオーラ', req:30000,   reqType:'point' },
+      { id:'kyunidol',      name:'きゅんきゅんアイドル', tap:2,   gen:1.1, prestige:1,   desc:'ときめきでタップ2倍',                    point:'ファンレター', req:1e6,    reqType:'power' },
+      { id:'melodysinger',  name:'メロディシンガー',     tap:2.5, gen:1.2, prestige:1.1, desc:'歌声でタップ2.5倍',                      point:'ファンレター', req:100,      reqType:'point' },
+      { id:'stagecinderella', name:'ステージシンデレラ', tap:3,   gen:1.3, prestige:1.2, desc:'舞台の輝きでタップ3倍',                 point:'ファンレター', req:1000,     reqType:'point' },
+      { id:'shinystar',     name:'シャイニースター',     tap:3.5, gen:1.4, prestige:1.3, desc:'星の煌めきでタップ3.5倍',               point:'ファンレター', req:10000,    reqType:'point' },
+      { id:'gloriousdiva',  name:'グロリアスディーヴァ', tap:4,   gen:1.5, prestige:1.4, desc:'栄光のステージでタップ4倍',             point:'ファンレター', req:100000,   reqType:'point' },
     ],
   },
-  {
-    id: 'glasses',
-    name: 'メガネ系',
-    jobs: [
-      { id:'booklover',       name:'ブックラバー',       tap:1.5, gen:1.5, prestige:1.5, desc:'読書の知恵で全て1.5倍',       point:'叡智の欠片', req:1e6,    reqType:'power' },
-      { id:'wonderresearcher',name:'ワンダーリサーチャー', tap:1.6, gen:1.6, prestige:1.6, desc:'研究の閃きで全て1.6倍',       point:'叡智の欠片', req:40,     reqType:'point' },
-      { id:'nobleprofessor',  name:'ノーブルプロフェッサー', tap:1.7, gen:1.7, prestige:1.7, desc:'高貴な教授で全て1.7倍',       point:'叡智の欠片', req:400,    reqType:'point' },
-      { id:'ancientsage',     name:'エンシェントセージ',   tap:1.8, gen:1.8, prestige:1.8, desc:'古代の叡智で全て1.8倍',       point:'叡智の欠片', req:4000,   reqType:'point' },
-      { id:'metatron',        name:'メタトロン＝アルカナ', tap:1.9, gen:1.9, prestige:1.9, desc:'究極の知恵で全て1.9倍',         point:'叡智の欠片', req:40000,  reqType:'point' },
-    ],
-  },
+    {
+      id: 'scholar',
+      name: '学者系',
+      jobs: [
+        { id:'booklover',       name:'ブックラバー',       tap:1, gen:1, prestige:1, upgCost:0.9, desc:'読書の知恵でジェネ強化コスト10%減',       point:'研究資料', req:1e6,    reqType:'power' },
+        { id:'wonderresearcher',name:'ワンダーリサーチャー', tap:1, gen:1, prestige:1, upgCost:0.85, desc:'研究の閃きでジェネ強化コスト15%減',       point:'研究資料', req:100,     reqType:'point' },
+        { id:'nobleprofessor',  name:'ノーブルプロフェッサー', tap:1, gen:1, prestige:1, upgCost:0.8, desc:'高貴な教授でジェネ強化コスト20%減',       point:'研究資料', req:1000,    reqType:'point' },
+        { id:'ancientsage',     name:'エンシェントセージ',   tap:1, gen:1, prestige:1, upgCost:0.75, desc:'古代の叡智でジェネ強化コスト25%減',       point:'研究資料', req:10000,   reqType:'point' },
+        { id:'metatron',        name:'メタトロン＝アルカナ', tap:1, gen:1, prestige:1, upgCost:0.7, desc:'究極の知恵でジェネ強化コスト30%減',         point:'研究資料', req:100000,  reqType:'point' },
+      ],
+    },
 ];
 
 export const JOBS = [
@@ -65,5 +65,7 @@ export const JOB_MAP = Object.fromEntries(JOBS.map(j => [j.id, j]));
 
 export function getJobBonuses(id){
   const j = JOB_MAP[id];
-  return j ? { tap:j.tap, gen:j.gen, prestige:j.prestige } : { tap:1, gen:1, prestige:1 };
+  return j
+    ? { tap:j.tap, gen:j.gen, prestige:j.prestige, pointGain:j.pointGain||1, upgCost:j.upgCost||1 }
+    : { tap:1, gen:1, prestige:1, pointGain:1, upgCost:1 };
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-export const VERSION = 'Ver.0.1.7.0';
+export const VERSION = 'Ver.0.1.8.0';
 import { GENERATORS } from './data.js';
 import { getJobBonuses, JOB_MAP } from './jobs.js';
 import { save, load, reset } from './save.js';
@@ -197,7 +197,7 @@ function __loop(ts){
     }
     const jobInfo = JOB_MAP[state.job];
     if(jobInfo && jobInfo.point && jobInfo.point !== 'なし'){
-      const gain = pps.times(dt).div(1e6);
+      const gain = pps.times(dt).div(1e6).times(jb.pointGain);
       const curr = state.jobPoints[jobInfo.point] || 0;
       state.jobPoints[jobInfo.point] = new Decimal(curr).plus(gain).toNumber();
     }
@@ -217,7 +217,7 @@ function __loop(ts){
 requestAnimationFrame(__loop);
 
 
-try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.7.0'; }catch(e){}
+try{ const v=document.getElementById('verText'); if(v) v.textContent='0.1.8.0'; }catch(e){}
 
 function flashRebirth(){
   try{

--- a/js/style.css
+++ b/js/style.css
@@ -126,7 +126,7 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 }
 
 
-/* === 0.1.7.0 UI color refinements === */
+/* === 0.1.8.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;

--- a/js/ui.js
+++ b/js/ui.js
@@ -282,8 +282,9 @@ function genRow(state, g, onUpdate){
   const tMa=row.querySelector('.tMa'), tMb=row.querySelector('.tMb'), tMd=row.querySelector('.tMd');
 
   function refresh(){
+    const jb = getJobBonuses(state.job);
     ownEl.textContent = fmt(g.count);
-    eachEl.textContent = fmt(powerFor(g).times(getJobBonuses(state.job).gen));
+    eachEl.textContent = fmt(powerFor(g).times(jb.gen));
 
     const nMax = maxAffordableUnits(g, state.power);
     const sumU = totalCostUnits(g, nMax);
@@ -297,9 +298,9 @@ function genRow(state, g, onUpdate){
       btnBuyM.textContent = `まとめ購入 ×${fmt(nMax)}（${fmt(sumU)}）`;
     }
 
-    const up1 = nextUpgradeCost(g);
-    const kMax = (g.count>0) ? maxAffordableUpgrades(g, state.power) : 0;
-    const sumK = totalCostUpgrades(g, kMax);
+    const up1 = nextUpgradeCost(g, jb);
+    const kMax = (g.count>0) ? maxAffordableUpgrades(g, state.power, jb) : 0;
+    const sumK = totalCostUpgrades(g, kMax, jb);
     if (btnUp1){
       btnUp1.disabled = state.power.lt(up1) || (g.count|0) <= 0;
       btnUp1.textContent = `強化＋1（${fmt(up1)}）`;
@@ -375,6 +376,7 @@ export function lightRefresh(state, onRebirth, handlers){
     const btnUp1 =row.querySelector('.up1');
     const btnUpM =row.querySelector('.upMax');
 
+    const jb = getJobBonuses(state.job);
     const nMax = maxAffordableUnits(g,state.power);
     const sumU = totalCostUnits(g,nMax);
     if(btnBuy1){
@@ -387,9 +389,9 @@ export function lightRefresh(state, onRebirth, handlers){
       btnBuyM.textContent = `まとめ購入 ×${fmt(nMax)}（${fmt(sumU)}）`;
     }
 
-    const up1 = nextUpgradeCost(g);
-    const kMax = (g.count>0) ? maxAffordableUpgrades(g,state.power) : 0;
-    const sumK = totalCostUpgrades(g,kMax);
+    const up1 = nextUpgradeCost(g, jb);
+    const kMax = (g.count>0) ? maxAffordableUpgrades(g,state.power, jb) : 0;
+    const sumK = totalCostUpgrades(g,kMax, jb);
     if(btnUp1){
       btnUp1.disabled = state.power.lt(up1) || (g.count|0) <= 0;
       btnUp1.textContent = `強化＋1（${fmt(up1)}）`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magical-clicker",
-  "version": "0.1.7.0",
+  "version": "0.1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
     "name": "magical-clicker",
-    "version": "0.1.7.0",
+    "version": "0.1.8.0",
       "license": "ISC",
       "dependencies": {
         "break_infinity.js": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-clicker",
-  "version": "0.1.7.0",
+  "version": "0.1.8.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -33,9 +33,9 @@ body{
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
 .clickgrid{ display:grid; grid-template-columns:1fr; gap:8px }
-.main{ display:flex; gap:12px }
-.left{ flex:1; display:flex; flex-direction:column; gap:8px }
-.right{ display:flex; flex-direction:column; gap:12px; min-width:320px }
+.main{ display:grid; grid-template-columns:1fr 360px; gap:12px; align-items:start }
+.left{ display:flex; flex-direction:column; gap:8px }
+.right{ grid-column:2; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -124,14 +124,14 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 
 /* ====== Responsive ====== */
 @media (max-width: 1100px){
-  .main{ flex-direction:column }
+  .main{ grid-template-columns:1fr }
   .clickgrid{ grid-template-columns:1fr }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
-  .right{ min-width:0 }
+  .right{ min-width:0; grid-column:1 }
 }
 
 
-/* === 0.1.7.0 UI color refinements === */
+/* === 0.1.8.0 UI color refinements === */
 :root{
   --buy:#ff6dc3; --buy-deep:#e054ad;
   --upg:#b67aff; --upg-deep:#8c5ebf;


### PR DESCRIPTION
## 概要
- 学者系を研究資料ボーナスからジェネレーター強化コスト軽減効果に変更
- 全職業系で上位職に必要なポイントを100/1,000/10,000/100,000に統一

## テスト
- `npm test` (エラー: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bc0c428fdc833194ba9d8b1520e7c8