### PR TITLE
レイアウト崩れの修正

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body{
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
 .clickgrid{ display:grid; grid-template-columns:1fr; gap:8px }
-.main{ display:grid; grid-template-columns:1fr 360px; gap:12px; align-items:start }
+.main{ display:grid; grid-template-columns:2fr 1fr; gap:12px; align-items:start }
 .left{ display:flex; flex-direction:column; gap:8px }
 .right{ grid-column:2; display:flex; flex-direction:column; gap:12px; min-width:320px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
@@ -87,7 +87,7 @@ body{
 .tap .big{ font-size:24px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:repeat(2,1fr); gap:12px; grid-auto-flow:column }
+.genlist{ display:grid; grid-template-columns:repeat(5,1fr); gap:12px }
 .gen{
   display:flex; flex-direction:column; gap:10px;
   padding:10px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);


### PR DESCRIPTION
## 概要
- メインレイアウトを左2/3・右1/3に調整
- ジェネレーターリストを5列で折り返し表示するよう変更

## テスト
- `npm test`（テスト未実装のためエラー）

------
https://chatgpt.com/codex/tasks/task_e_68bc4e5af6808331817f02ca378e3466