### PR TITLE
ジェネレーターグリッドとレイアウト調整

### DIFF
--- a/js/style.css
+++ b/js/style.css
@@ -36,7 +36,7 @@ body{
 .clickgrid{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
 .left{ grid-column:1 / span 2; grid-row:3; }
 .genpanel{ grid-column:1 / span 2; }
-.right{ grid-column:3; grid-row:2; display:flex; flex-direction:column; gap:12px; min-width:320px }
+.right{ grid-column:3; grid-row:2; display:flex; flex-direction:column; gap:12px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -88,7 +88,7 @@ body{
 .tap .big{ font-size:36px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:repeat(2,1fr); gap:20px; grid-auto-flow:row }
+.genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:20px; grid-auto-flow:row }
 .gen{
   display:flex; flex-direction:column; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -116,13 +116,13 @@ body{
 footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 
 /* ====== Responsive ====== */
-@media (max-width: 1100px){
+@media (max-width: 700px){
   .container{ grid-template-columns:1fr; }
   .genpanel{ grid-column:1; }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
   .clickgrid{ grid-template-columns:1fr }
   .left{ grid-column:1; grid-row:auto; }
-  .right{ grid-column:1; grid-row:auto; min-width:0 }
+  .right{ grid-column:1; grid-row:auto; }
 }
 
 

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ body{
 .clickgrid{ display:grid; grid-template-columns:1fr; gap:8px }
 .main{ display:grid; grid-template-columns:2fr 1fr; gap:12px; align-items:start }
 .left{ display:flex; flex-direction:column; gap:8px }
-.right{ grid-column:2; display:flex; flex-direction:column; gap:12px; min-width:320px }
+.right{ grid-column:2; display:flex; flex-direction:column; gap:12px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -87,7 +87,7 @@ body{
 .tap .big{ font-size:24px }
 
 /* ====== Generator list ====== */
-.genlist{ display:grid; grid-template-columns:repeat(5,1fr); gap:12px }
+.genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:12px }
 .gen{
   display:flex; flex-direction:column; gap:10px;
   padding:10px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
@@ -123,7 +123,7 @@ body{
 footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 
 /* ====== Responsive ====== */
-@media (max-width: 1100px){
+@media (max-width: 700px){
   .main{ grid-template-columns:1fr }
   .clickgrid{ grid-template-columns:1fr }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }


### PR DESCRIPTION
## 概要
- ジェネレーター一覧を3列×4段に並び替え
- レスポンシブ閾値を700pxに引き下げ、狭幅でも左右2:1レイアウト維持
- 右カラムの最小幅制限を撤廃

## テスト
- `npm test` : エラー (テスト未設定)


------
https://chatgpt.com/codex/tasks/task_e_68bf824fe8d88331a0c539d66cff06f8