### PR TITLE
左右レイアウトを常に2:1で固定

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,9 +33,13 @@ body{
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
 .clickgrid{ display:grid; grid-template-columns:1fr; gap:8px }
-.main{ display:grid; grid-template-columns:2fr 1fr; gap:12px; align-items:start }
-.left{ display:flex; flex-direction:column; gap:8px }
-.right{ grid-column:2; display:flex; flex-direction:column; gap:12px }
+/*
+ * メイン領域は常に2:1で横並びさせるためフレックスレイアウトを採用
+ * 左ペインを2、右ペインを1の比率で伸縮させる
+ */
+.main{ display:flex; gap:12px; align-items:flex-start }
+.left{ flex:2; display:flex; flex-direction:column; gap:8px }
+.right{ flex:1; display:flex; flex-direction:column; gap:12px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -124,10 +128,8 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 
 /* ====== Responsive ====== */
 @media (max-width: 700px){
-  .main{ grid-template-columns:1fr }
   .clickgrid{ grid-template-columns:1fr }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
-  .right{ min-width:0; grid-column:1 }
 }
 
 


### PR DESCRIPTION
## Summary
- メイン領域をFlexbox化し、左2/3・右1/3の比率を常に維持
- 幅700px以下でも横並びになるようメディアクエリを整理

## Testing
- `npm test` （`Error: no test specified`）

------
https://chatgpt.com/codex/tasks/task_e_68bf8af812148331bde74800bff86e23