### PR TITLE
js版レイアウトをフレックス2:1に統一

### DIFF
--- a/js/index.html
+++ b/js/index.html
@@ -15,42 +15,43 @@
       <span class="pill">表記：科学（簡易）</span>
     </header>
 
-    <div class="col main">
-      <!-- タップ（ハートを獲得する場所） -->
-      <div class="panel">
-        <div class="hd frill frill-pink"><strong>エンジェルハートタップ</strong><span class="muted">（タップでエンジェルハートを獲得）</span></div>
-        <div class="bd">
-          <div class="stat">
-            <span>エンジェルハート：</span><span class="big" id="power">0</span>
-          </div>
-          <div class="pill mt8">ハート/秒：<span id="pps">0</span></div>
-          <div class="tap mt12">
-            <div>現在のタップ：<span class="big" id="tapGain">+1.00</span></div>
-            <div class="row center mt8">
-              <button id="tapBtn" class="btn tapbtn">ハートタップ！</button>
+    <div class="main">
+      <div class="left">
+        <!-- タップ（ハートを獲得する場所） -->
+        <div class="panel">
+          <div class="hd frill frill-pink"><strong>エンジェルハートタップ</strong><span class="muted">（タップでエンジェルハートを獲得）</span></div>
+          <div class="bd">
+            <div class="stat">
+              <span>エンジェルハート：</span><span class="big" id="power">0</span>
+            </div>
+            <div class="pill mt8">ハート/秒：<span id="pps">0</span></div>
+            <div class="tap mt12">
+              <div>現在のタップ：<span class="big" id="tapGain">+1.00</span></div>
+              <div class="row center mt8">
+                <button id="tapBtn" class="btn tapbtn">ハートタップ！</button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- メイドスマイル強化（位置を分離） -->
-      <div class="panel">
-        <div class="hd frill frill-green frill-top"><strong>メイドスマイル強化</strong></div>
-        <div class="bd">
-          <div class="row wrap">
-            <span class="pill" id="clickLvInfo">Lv 0</span>
-            <span class="pill">次レベル効果：<span id="clickDelta">+0</span></span>
-            <span class="pill">次レベル費用：<span id="clickCost">0</span></span>
-            <span class="pill">適用後タップ：<span id="clickAfter">+0</span></span>
-          </div>
-          <div class="row center mt12">
-            <button id="upgradeClick" class="btn up">強化 +1</button>
-            <button id="upgradeClickMax" class="btn up alt">最大強化 ×0</button>
+        <!-- メイドスマイル強化（位置を分離） -->
+        <div class="panel">
+          <div class="hd frill frill-green frill-top"><strong>メイドスマイル強化</strong></div>
+          <div class="bd">
+            <div class="row wrap">
+              <span class="pill" id="clickLvInfo">Lv 0</span>
+              <span class="pill">次レベル効果：<span id="clickDelta">+0</span></span>
+              <span class="pill">次レベル費用：<span id="clickCost">0</span></span>
+              <span class="pill">適用後タップ：<span id="clickAfter">+0</span></span>
+            </div>
+            <div class="row center mt12">
+              <button id="upgradeClick" class="btn up">強化 +1</button>
+              <button id="upgradeClickMax" class="btn up alt">最大強化 ×0</button>
+            </div>
           </div>
         </div>
-      </div>
 
-      <!-- ジェネレーター -->
+        <!-- ジェネレーター -->
         <div class="panel">
           <div class="hd frill frill-yellow frill-zigzag">
             <strong>エンジェルメイドユニット</strong>
@@ -60,9 +61,9 @@
             <div class="genlist" id="genlist"></div>
           </div>
         </div>
-    </div>
+      </div>
 
-    <aside class="right">
+      <aside class="right">
         <div class="panel">
           <div class="hd frill frill-pink frill-double"><strong>アイドル覚醒</strong></div>
           <div class="bd">
@@ -73,22 +74,23 @@
             <div class="rebirths" id="rebirthList"></div>
           </div>
         </div>
-      <div class="panel">
-        <div class="hd frill frill-green frill-wave"><strong>転生特典</strong></div>
-        <div class="bd" id="featurePanel"></div>
-      </div>
+        <div class="panel">
+          <div class="hd frill frill-green frill-wave"><strong>転生特典</strong></div>
+          <div class="bd" id="featurePanel"></div>
+        </div>
 
-      <div class="panel">
-        <div class="hd frill frill-yellow frill-wave"><strong>システム</strong></div>
-        <div class="bd">
-          <div class="row">
-            <button id="saveBtn" class="btn good">保存</button>
-            <button id="loadBtn" class="btn">読込</button>
-            <button id="resetBtn" class="btn danger ml-auto">ハードリセット</button>
+        <div class="panel">
+          <div class="hd frill frill-yellow frill-wave"><strong>システム</strong></div>
+          <div class="bd">
+            <div class="row">
+              <button id="saveBtn" class="btn good">保存</button>
+              <button id="loadBtn" class="btn">読込</button>
+              <button id="resetBtn" class="btn danger ml-auto">ハードリセット</button>
+            </div>
           </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </div>
 
     <footer class="muted center">スマイル×4^Lv / 全体×1.03^Lv。PPSは毎フレーム加算＆表示。</footer>
   </div>

--- a/js/style.css
+++ b/js/style.css
@@ -34,9 +34,10 @@ body{
 /* ====== Grids / Flex ====== */
 .col{ display:flex; flex-direction:column; gap:16px }
 .clickgrid{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
-.left{ grid-column:1 / span 2; grid-row:3; }
-.genpanel{ grid-column:1 / span 2; }
-.right{ grid-column:3; grid-row:2; display:flex; flex-direction:column; gap:12px }
+/* Flexbox layout: main container with 2:1 columns */
+.main{ grid-column:1 / span 3; display:flex; gap:12px; align-items:flex-start }
+.left{ flex:2; display:flex; flex-direction:column; gap:8px }
+.right{ flex:1; display:flex; flex-direction:column; gap:12px }
 .row{ display:flex; gap:20px; align-items:center; flex-wrap:wrap }
 .wrap{ flex-wrap:wrap } .center{ justify-content:center }
 .grid2{ display:grid; grid-template-columns:1fr 1fr; gap:16px }
@@ -118,11 +119,9 @@ footer.center{ text-align:center; padding:12px 0; color:#bfb7e8 }
 /* ====== Responsive ====== */
 @media (max-width: 700px){
   .container{ grid-template-columns:1fr; }
-  .genpanel{ grid-column:1; }
   .genlist{ grid-template-columns:1fr; grid-auto-flow:row }
   .clickgrid{ grid-template-columns:1fr }
-  .left{ grid-column:1; grid-row:auto; }
-  .right{ grid-column:1; grid-row:auto; }
+  .main{ grid-column:1; }
 }
 
 


### PR DESCRIPTION
## 概要
- js/style.cssに.main/.left/.rightを追加し、ルート版と同様の2:1フレックスレイアウトを適用
- js/index.htmlから`col`クラスを除去し、左ペインと右ペインを.flexレイアウトで構成

## テスト
- `npm test` (エラー: no test specified)
- `chromium-browser --headless --disable-gpu --screenshot=js_layout.png js/index.html` (snap未導入のため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68c18c8772a483318aba05094092719d