### PR TITLE
ジェネレータ行の左右クラス名を専用化

### DIFF
--- a/js/style.css
+++ b/js/style.css
@@ -90,7 +90,7 @@ body{
 
 /* ====== Generator list ====== */
 .genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:20px; grid-auto-flow:row }
-.gen{
+.gen{ 
   display:flex; flex-direction:column; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
 }
@@ -98,6 +98,8 @@ body{
 .gen:nth-child(even){ background:rgba(255,255,255,.06) }
 .gen .name{ font-weight:900; margin-bottom:6px; font-size:24px }
 .gen .desc{ font-size:18px; color:#c6c0ea }
+.gen-left{ flex:2; display:flex; flex-direction:column; gap:8px }
+.gen-right{ flex:1; display:flex; flex-direction:column; gap:12px }
 
 /* ====== Rebirth list ====== */
 .rebirths{ display:flex; flex-direction:column; gap:12px }

--- a/js/ui.js
+++ b/js/ui.js
@@ -238,7 +238,7 @@ function genRow(state, g, onUpdate){
   const row = document.createElement('div');
   row.className = 'gen';
   row.innerHTML = `
-    <div class="left">
+    <div class="gen-left">
       <div class="name">${g.name} <span class="muted">x<span class="own">${fmt(g.count)}</span></span></div>
       <div class="desc">単体/sec: <span class="eachPps">${fmt(powerFor(g))}</span></div>
       <div class="desc lvline">Lv <span class="lvNow">0</span> → <span class="lvNext">1</span></div>
@@ -249,7 +249,7 @@ function genRow(state, g, onUpdate){
         まとめ強化効果：単体 <span class="eMa"></span> → <span class="eMb"></span>（+<span class="eMd"></span>）｜全体 <span class="tMa"></span> → <span class="tMb"></span>（+<span class="tMd"></span>）
       </div>
     </div>
-    <div class="right">
+    <div class="gen-right">
       <div class="buttons">
         <div class="row">
           <button class="btn buy1">購入</button>

--- a/style.css
+++ b/style.css
@@ -92,7 +92,7 @@ body{
 
 /* ====== Generator list ====== */
 .genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:12px }
-.gen{
+.gen{ 
   display:flex; flex-direction:column; gap:10px;
   padding:10px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
 }
@@ -100,6 +100,8 @@ body{
 .gen:nth-child(even){ background:rgba(255,255,255,.06) }
 .gen .name{ font-weight:900; margin-bottom:4px; font-size:20px }
 .gen .desc{ font-size:16px; color:#c6c0ea }
+.gen-left{ flex:2; display:flex; flex-direction:column; gap:8px }
+.gen-right{ flex:1; display:flex; flex-direction:column; gap:12px }
 
 /* Compact panels for click and generator sections */
 .clickgrid .hd,


### PR DESCRIPTION
## 概要
- ジェネレーター行テンプレートの左右カラムを固有クラス（gen-left / gen-right）に変更しました
- 新クラス向けのスタイルを style.css / js/style.css に追加し、従来の .left / .right から独立させました
- `.left` / `.right` の利用箇所を調査し、他コンポーネントへの影響が無いことを確認しました

## テスト
- なし

------
https://chatgpt.com/codex/tasks/task_e_68c93a9369f88331bf4cd1c1c24c355d