### PR TITLE
ジェネレータ列のフォールバックスタイルを追加

### DIFF
--- a/js/style.css
+++ b/js/style.css
@@ -90,7 +90,7 @@ body{
 
 /* ====== Generator list ====== */
 .genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:20px; grid-auto-flow:row }
-.gen{
+.gen{ 
   display:flex; flex-direction:column; gap:16px;
   padding:14px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
 }
@@ -98,6 +98,8 @@ body{
 .gen:nth-child(even){ background:rgba(255,255,255,.06) }
 .gen .name{ font-weight:900; margin-bottom:6px; font-size:24px }
 .gen .desc{ font-size:18px; color:#c6c0ea }
+.gen-left{ flex:2; display:flex; flex-direction:column; gap:8px; min-width:0 }
+.gen-right{ flex:1; display:flex; flex-direction:column; gap:12px; min-width:0 }
 
 /* ====== Rebirth list ====== */
 .rebirths{ display:flex; flex-direction:column; gap:12px }

--- a/js/ui.js
+++ b/js/ui.js
@@ -234,11 +234,32 @@ function simulateTotalAfterUpgrade(state, g, n){
   return { beforeEach, afterEach, deltaEach, beforeTotal, afterTotal, deltaTotal };
 }
 
+let generatorColumnStylesEnsured = false;
+function ensureGeneratorColumnStyles(){
+  if(generatorColumnStylesEnsured) return;
+  if(typeof document === 'undefined') return;
+  const head = document.head;
+  if(!head) return;
+  if(document.getElementById('gen-column-style')){
+    generatorColumnStylesEnsured = true;
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = 'gen-column-style';
+  style.textContent = `
+#genlist .gen-left{flex:2;display:flex;flex-direction:column;gap:8px;min-width:0}
+#genlist .gen-right{flex:1;display:flex;flex-direction:column;gap:12px;min-width:0}
+`.trim();
+  head.appendChild(style);
+  generatorColumnStylesEnsured = true;
+}
+
 function genRow(state, g, onUpdate){
+  ensureGeneratorColumnStyles();
   const row = document.createElement('div');
   row.className = 'gen';
   row.innerHTML = `
-    <div class="left">
+    <div class="gen-left">
       <div class="name">${g.name} <span class="muted">x<span class="own">${fmt(g.count)}</span></span></div>
       <div class="desc">単体/sec: <span class="eachPps">${fmt(powerFor(g))}</span></div>
       <div class="desc lvline">Lv <span class="lvNow">0</span> → <span class="lvNext">1</span></div>
@@ -249,7 +270,7 @@ function genRow(state, g, onUpdate){
         まとめ強化効果：単体 <span class="eMa"></span> → <span class="eMb"></span>（+<span class="eMd"></span>）｜全体 <span class="tMa"></span> → <span class="tMb"></span>（+<span class="tMd"></span>）
       </div>
     </div>
-    <div class="right">
+    <div class="gen-right">
       <div class="buttons">
         <div class="row">
           <button class="btn buy1">購入</button>

--- a/style.css
+++ b/style.css
@@ -92,7 +92,7 @@ body{
 
 /* ====== Generator list ====== */
 .genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:12px }
-.gen{
+.gen{ 
   display:flex; flex-direction:column; gap:10px;
   padding:10px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
 }
@@ -100,6 +100,8 @@ body{
 .gen:nth-child(even){ background:rgba(255,255,255,.06) }
 .gen .name{ font-weight:900; margin-bottom:4px; font-size:20px }
 .gen .desc{ font-size:16px; color:#c6c0ea }
+.gen-left{ flex:2; display:flex; flex-direction:column; gap:8px; min-width:0 }
+.gen-right{ flex:1; display:flex; flex-direction:column; gap:12px; min-width:0 }
 
 /* Compact panels for click and generator sections */
 .clickgrid .hd,


### PR DESCRIPTION
## 概要
- ジェネレーター行の左右カラムに対応するスタイルを動的に補うフォールバックを追加し、関連ファイル削除時にもレイアウトが崩れないようにしました
- `.gen-left` / `.gen-right` に `min-width: 0` を設定し、スタイルが欠けた場合でも列が正しく縮退するように調整しました

## テスト
- なし

------
https://chatgpt.com/codex/tasks/task_e_68c93a9369f88331bf4cd1c1c24c355d