### PR TITLE
ジェネレータ行クラス名の衝突を回避

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -238,7 +238,7 @@ function genRow(state, g, onUpdate){
   const row = document.createElement('div');
   row.className = 'gen';
   row.innerHTML = `
-    <div class="left">
+    <div class="gen-left">
       <div class="name">${g.name} <span class="muted">x<span class="own">${fmt(g.count)}</span></span></div>
       <div class="desc">単体/sec: <span class="eachPps">${fmt(powerFor(g))}</span></div>
       <div class="desc lvline">Lv <span class="lvNow">0</span> → <span class="lvNext">1</span></div>
@@ -249,7 +249,7 @@ function genRow(state, g, onUpdate){
         まとめ強化効果：単体 <span class="eMa"></span> → <span class="eMb"></span>（+<span class="eMd"></span>）｜全体 <span class="tMa"></span> → <span class="tMb"></span>（+<span class="tMd"></span>）
       </div>
     </div>
-    <div class="right">
+    <div class="gen-right">
       <div class="buttons">
         <div class="row">
           <button class="btn buy1">購入</button>

--- a/style.css
+++ b/style.css
@@ -92,10 +92,12 @@ body{
 
 /* ====== Generator list ====== */
 .genlist{ display:grid; grid-template-columns:repeat(3,1fr); gap:12px }
-.gen{
+.gen{ 
   display:flex; flex-direction:column; gap:10px;
   padding:10px; border:1px solid #2c2950; border-radius:14px; background:rgba(255,255,255,.03);
 }
+.gen-left{ flex:2; display:flex; flex-direction:column; gap:8px }
+.gen-right{ flex:1; display:flex; flex-direction:column; gap:12px }
 .gen:nth-child(odd){ background:rgba(255,255,255,.03) }
 .gen:nth-child(even){ background:rgba(255,255,255,.06) }
 .gen .name{ font-weight:900; margin-bottom:4px; font-size:20px }


### PR DESCRIPTION
## Summary
- ジェネレーター行テンプレートのクラス名を `gen-left` / `gen-right` に変更
- `style.css` にジェネレーター専用の左右カラム用スタイルを追加し、`.left` / `.right` と切り離し
- `.left` / `.right` クラスがメインレイアウトのみに使われていることを確認

## Testing
- なし

------
https://chatgpt.com/codex/tasks/task_e_68c94248b8e08331900edb37ad725b34