### PR TITLE
バランス調整：中盤〜終盤のインフレを大幅抑制

### DIFF
--- a/js/click.js
+++ b/js/click.js
@@ -1,17 +1,17 @@
-// メイドスマイル強化仕様：タップ威力 = base * 4^Lv、全体倍率 = 1.03^Lv
-// コスト：125 * 5^Lv
+// メイドスマイル強化仕様：タップ威力 = base * 3^Lv、全体倍率 = 1.015^Lv
+// コスト：150 * 6^Lv
 export const CLICK = {
-  baseClick: new Decimal(1),
+  baseClick: new Decimal(0.5),
 };
 
 export function clickGainByLevel(lv){
-  return CLICK.baseClick.times(Decimal.pow(4, lv));
+  return CLICK.baseClick.times(Decimal.pow(3, lv));
 }
 export function globalMultiplier(lv){
-  return Decimal.pow(1.03, lv);
+  return Decimal.pow(1.015, lv);
 }
 export function clickNextCost(lv){
-  return new Decimal(125).times(Decimal.pow(5, lv));
+  return new Decimal(150).times(Decimal.pow(6, lv));
 }
 export function clickNextDelta(lv){
   return clickGainByLevel(lv+1).minus(clickGainByLevel(lv));
@@ -23,7 +23,7 @@ export function clickTotalCost(lv, n){
   let cost = clickNextCost(lv);
   for(let i=0;i<n;i++){
     total = total.plus(cost);
-    cost = cost.times(5);
+    cost = cost.times(6);
   }
   return total;
 }
@@ -35,7 +35,7 @@ export function maxAffordableClicks(lv, budget){
   while (budget.gte(cost) && n < 1e6){
     budget = budget.minus(cost);
     n++;
-    cost = cost.times(5);
+    cost = cost.times(6);
   }
   return n;
 }

--- a/js/economy.js
+++ b/js/economy.js
@@ -2,16 +2,16 @@ import { getJobBonuses } from './jobs.js';
 const D = (x)=> new Decimal(x);
 
 export const DEFAULTS = {
-  g1:{ basePps:D(0.2),    baseCost:D(13.2),   costMul:D(1.15), upBaseCost:D(55),     upCostMul:D(1.17) },
-  g2:{ basePps:D(2.0),    baseCost:D(88),     costMul:D(1.17), upBaseCost:D(275),    upCostMul:D(1.18) },
-  g3:{ basePps:D(15.8),   baseCost:D(770),    costMul:D(1.18), upBaseCost:D(1100),   upCostMul:D(1.19) },
-  g4:{ basePps:D(127),    baseCost:D(5940),   costMul:D(1.20), upBaseCost:D(4400),   upCostMul:D(1.20) },
-  g5:{ basePps:D(1.03e3), baseCost:D(4.4e4),  costMul:D(1.21), upBaseCost:D(1.87e4), upCostMul:D(1.21) },
-  g6:{ basePps:D(8.3e3),  baseCost:D(3.3e5),  costMul:D(1.22), upBaseCost:D(8.8e4),  upCostMul:D(1.22) },
-  g7:{ basePps:D(6.73e4), baseCost:D(2.42e6), costMul:D(1.23), upBaseCost:D(4.07e5), upCostMul:D(1.23) },
-  g8:{ basePps:D(5.35e5), baseCost:D(1.87e7), costMul:D(1.24), upBaseCost:D(1.87e6), upCostMul:D(1.24) },
-  g9:{ basePps:D(4.16e6), baseCost:D(1.32e8), costMul:D(1.25), upBaseCost:D(8.25e6), upCostMul:D(1.25) },
-  g10:{ basePps:D(3.33e7), baseCost:D(9.9e8), costMul:D(1.26), upBaseCost:D(3.7e7),  upCostMul:D(1.26) },
+  g1:{ basePps:D(0.15),    baseCost:D(18),     costMul:D(1.17), upBaseCost:D(75),     upCostMul:D(1.19) },
+  g2:{ basePps:D(1.2),     baseCost:D(140),    costMul:D(1.19), upBaseCost:D(460),    upCostMul:D(1.20) },
+  g3:{ basePps:D(9.0),     baseCost:D(1200),   costMul:D(1.20), upBaseCost:D(1800),   upCostMul:D(1.21) },
+  g4:{ basePps:D(70),      baseCost:D(9800),   costMul:D(1.22), upBaseCost:D(7200),   upCostMul:D(1.22) },
+  g5:{ basePps:D(5.0e2),   baseCost:D(8.4e4),  costMul:D(1.23), upBaseCost:D(3.6e4),  upCostMul:D(1.23) },
+  g6:{ basePps:D(3.5e3),   baseCost:D(6.6e5),  costMul:D(1.24), upBaseCost:D(1.8e5),  upCostMul:D(1.24) },
+  g7:{ basePps:D(2.4e4),   baseCost:D(5.1e6),  costMul:D(1.25), upBaseCost:D(8.8e5),  upCostMul:D(1.25) },
+  g8:{ basePps:D(1.7e5),   baseCost:D(4.3e7),  costMul:D(1.26), upBaseCost:D(4.2e6),  upCostMul:D(1.26) },
+  g9:{ basePps:D(1.1e6),   baseCost:D(3.4e8),  costMul:D(1.27), upBaseCost:D(2.0e7),  upCostMul:D(1.27) },
+  g10:{ basePps:D(7.0e6),  baseCost:D(2.9e9),  costMul:D(1.28), upBaseCost:D(9.5e7),  upCostMul:D(1.28) },
 };
 
 function ensureParams(gen){
@@ -28,8 +28,8 @@ function ensureParams(gen){
 export function powerFor(gen){
   ensureParams(gen);
   const lv = gen.level|0;
-  const linear = Decimal.pow(1.10, lv);
-  const step   = Decimal.pow(2, Math.floor(lv/10));
+  const linear = Decimal.pow(1.08, lv);
+  const step   = Decimal.pow(1.5, Math.floor(lv/10));
   return gen.basePps.times(linear).times(step);
 }
 
@@ -134,4 +134,3 @@ export function upgrade(state, id, mode='1'){
   g.level = (g.level|0) + n;
   return true;
 }
-

--- a/js/prestige.js
+++ b/js/prestige.js
@@ -1,22 +1,21 @@
 export const REBIRTHS = [
-  { level:1, name:'ピュアハート',           req:10,    effect:'全体倍率×1e3',   feature:'オートタップが解禁（ボタンでON/OFF）' },
-  { level:2, name:'パステルドリーム',       req:1e6,   effect:'全体倍率×1e6',   feature:'ジェネレーター転生が解禁（ボタンで実行）' },
-  { level:3, name:'サニーフラグメント',     req:1e12,  effect:'全体倍率×1e12',  feature:'自動ユニット購入が解禁（ボタンでON/OFF）' },
-  { level:4, name:'マジカルプリンセス',     req:1e24,  effect:'全体倍率×1e24',  feature:'スタークリスタル変換が解禁（ボタンで変換）' },
-  { level:5, name:'セラフィムクイーン',     req:1e48,  effect:'全体倍率×1e48',  feature:'ハイパーモードが解禁（ボタンで発動）' },
-  { level:6, name:'ホーリーブライト',       req:1e96,  effect:'全体倍率×1e96',  feature:'自動スマイル強化が解禁（ボタンでON/OFF）' },
-  { level:7, name:'エターナルエンプレス',   req:1e192, effect:'全体倍率×1e192', feature:'ギャラクシーサージが解禁（ボタンで1e6倍）' },
+  { level:1, name:'ピュアハート',           req:1e2,   effect:'全体倍率×1e3',   feature:'オートタップが解禁（ボタンでON/OFF）' },
+  { level:2, name:'パステルドリーム',       req:1e8,   effect:'全体倍率×1e4',   feature:'ジェネレーター転生が解禁（ボタンで実行）' },
+  { level:3, name:'サニーフラグメント',     req:1e16,  effect:'全体倍率×1e6',   feature:'自動ユニット購入が解禁（ボタンでON/OFF）' },
+  { level:4, name:'マジカルプリンセス',     req:1e28,  effect:'全体倍率×1e9',   feature:'スタークリスタル変換が解禁（ボタンで変換）' },
+  { level:5, name:'セラフィムクイーン',     req:1e44,  effect:'全体倍率×1e13',  feature:'ハイパーモードが解禁（ボタンで発動）' },
+  { level:6, name:'ホーリーブライト',       req:1e64,  effect:'全体倍率×1e18',  feature:'自動スマイル強化が解禁（ボタンでON/OFF）' },
+  { level:7, name:'エターナルエンプレス',   req:1e96,  effect:'全体倍率×1e24',  feature:'ギャラクシーサージが解禁（ボタンで1e6倍）' },
 ];
 
 export function prestigeGain(power){
   const p = (power instanceof Decimal) ? power : new Decimal(power);
-  if (p.lt(1e6)) return 0;
-  return p.div(1e6).sqrt().floor().toNumber();
+  if (p.lt(1e8)) return 0;
+  return p.div(1e8).pow(1/3).floor().toNumber();
 }
 
-const MULTIPLIERS = [1, 1e3, 1e6, 1e12, 1e24, 1e48, 1e96, 1e192];
+const MULTIPLIERS = [1, 1e3, 1e4, 1e6, 1e9, 1e13, 1e18, 1e24];
 
 export function rebirthMultiplier(level){
   return MULTIPLIERS[level] || 1;
 }
-


### PR DESCRIPTION
### Motivation
- 以前の調整が小規模だったため、ユーザー要望に従い中盤以降のインフレをより強く抑制する目的で大幅なリバランスを行いました。 
- ジェネレーターとクリックの成長曲線が急すぎてコンテンツが早期消化される問題を緩和する必要があります。 
- 転生（プレステージ）周りの閾値と倍率が極端だったため、獲得カーブと効果を穏やかにしました。 

### Description
- `js/economy.js` のジェネレーター基礎値（g1〜g10）の `basePps` / `baseCost` / `costMul` / `upBaseCost` / `upCostMul` を大幅に調整し、成長の総量を抑えました。さらにレベルごとの線形成長を `1.10^lv` → `1.08^lv`、10レベル区切りの段階倍率を `2^k` → `1.5^k` に調整しました。 
- `js/click.js` でクリック強化を再設計し、`baseClick` を `1` → `0.5` に下げ、レベル増加による倍率を `4^lv` → `3^lv` に抑え、全体倍率を `1.03^lv` → `1.015^lv` に減少させました。クリックアップグレードのコスト基底を `125` → `150` に変更し、成長率は `5^lv` → `6^lv` に変更して短期的なクリック偏重を抑えています（関連する合計コスト計算と最大購入計算も同様に更新）。 
- `js/prestige.js` の `REBIRTHS` 定義を見直して各段階の必要電力と表示効果を再設計し、`prestigeGain` の閾値を `1e6` → `1e8` に上げつつ獲得カーブを平方根から立方根（`sqrt` → `pow(1/3)`）に変更し、内部 `MULTIPLIERS` を段階的に穏やかな値へ置換しました。 

### Testing
- 自動化されたテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e908157c83319640aeaf4d2e6fa5)