### PR TITLE
Introduce tabbed UI, ambient background orbs, and tap/power animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
   <link rel="stylesheet" href="./style.css">
 </head>
 <body>
+  <div class="ambient-layer" aria-hidden="true">
+    <span class="ambient-orb orb-a"></span>
+    <span class="ambient-orb orb-b"></span>
+    <span class="ambient-orb orb-c"></span>
+  </div>
+
   <div class="page">
     <header class="app-header">
       <div class="title-group">
@@ -16,112 +22,129 @@
       <button id="fmtToggle" class="btn ghost">表記：日本式</button>
     </header>
 
-    <main class="layout">
-      <section class="column column-left">
-        <section class="panel score-panel">
-          <header class="panel-header">
-            <h2>ステータス</h2>
-          </header>
-          <div class="panel-body score-body">
-            <div class="score-line">
-              <span class="score-label">エンジェルハート</span>
-              <span id="power" class="score-value">0</span>
-            </div>
-            <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
-          </div>
-        </section>
+    <nav class="main-tabs" aria-label="メインタブ">
+      <button class="tab-btn active" data-tab-target="growth">育成</button>
+      <button class="tab-btn" data-tab-target="advanced">覚醒・拡張</button>
+      <button class="tab-btn" data-tab-target="system">システム</button>
+    </nav>
 
-        <section class="panel click-panel">
-          <header class="panel-header">
-            <h2>エンジェルハートタップ</h2>
-            <p class="panel-sub">タップしてエンジェルハートを獲得</p>
-          </header>
-          <div class="panel-body click-body">
-            <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
-            <div class="tap-action">
-              <button id="tapBtn" class="btn main">ハートタップ！</button>
+    <main class="layout tab-panels">
+      <section class="tab-panel active" data-tab-panel="growth">
+        <section class="column column-left">
+          <section class="panel score-panel">
+            <header class="panel-header">
+              <h2>ステータス</h2>
+            </header>
+            <div class="panel-body score-body">
+              <div class="score-line">
+                <span class="score-label">エンジェルハート</span>
+                <span id="power" class="score-value">0</span>
+              </div>
+              <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
             </div>
+          </section>
 
-            <div class="upgrade-block">
-              <div class="upgrade-head">
-                <h3>メイドスマイル強化</h3>
-                <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
+          <section class="panel click-panel">
+            <header class="panel-header">
+              <h2>エンジェルハートタップ</h2>
+              <p class="panel-sub">タップしてエンジェルハートを獲得</p>
+            </header>
+            <div class="panel-body click-body">
+              <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
+              <div class="tap-action">
+                <div class="tap-zone">
+                  <button id="tapBtn" class="btn main">ハートタップ！</button>
+                  <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
+                </div>
               </div>
 
-              <dl class="upgrade-detail">
-                <div>
-                  <dt>単体強化（+1）</dt>
-                  <dd>
-                    スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
-                    全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
-                  </dd>
+              <div class="upgrade-block">
+                <div class="upgrade-head">
+                  <h3>メイドスマイル強化</h3>
+                  <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
                 </div>
-                <div>
-                  <dt>まとめ強化</dt>
-                  <dd>
-                    スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
-                    全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
-                  </dd>
-                </div>
-              </dl>
 
-              <div class="upgrade-buttons">
-                <button id="upgradeClick" class="btn sub">単体強化</button>
-                <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
+                <dl class="upgrade-detail">
+                  <div>
+                    <dt>単体強化（+1）</dt>
+                    <dd>
+                      スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
+                      全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>まとめ強化</dt>
+                    <dd>
+                      スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
+                      全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
+                    </dd>
+                  </div>
+                </dl>
+
+                <div class="upgrade-buttons">
+                  <button id="upgradeClick" class="btn sub">単体強化</button>
+                  <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
+                </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section class="panel generator-panel">
-          <header class="panel-header">
-            <h2>ジェネレーター</h2>
-            <p class="panel-sub">購入はピンク、強化はラベンダーで表示されます</p>
-          </header>
-          <div class="panel-body">
-            <div id="genlist" class="genlist"></div>
-          </div>
+          <section class="panel generator-panel">
+            <header class="panel-header">
+              <h2>ジェネレーター</h2>
+              <p class="panel-sub">購入はピンク、強化はラベンダーで表示されます</p>
+            </header>
+            <div class="panel-body">
+              <div id="genlist" class="genlist"></div>
+            </div>
+          </section>
         </section>
       </section>
 
-      <section class="column column-right">
-        <section class="panel prestige-panel">
-          <header class="panel-header">
-            <h2>アイドル覚醒</h2>
-          </header>
-          <div class="panel-body">
-            <div class="info-box muted">所持スタークリスタル：<span id="prestigeCurr">0</span></div>
-            <div class="info-box">
-              <div>次覚醒で獲得：<span id="prestigeGain">0</span></div>
-              <button id="prestigeBtn" class="btn warn block">覚醒する</button>
+      <section class="tab-panel" data-tab-panel="advanced">
+        <section class="column column-right">
+          <section class="panel prestige-panel">
+            <header class="panel-header">
+              <h2>アイドル覚醒</h2>
+            </header>
+            <div class="panel-body">
+              <div class="info-box muted">所持スタークリスタル：<span id="prestigeCurr">0</span></div>
+              <div class="info-box">
+                <div>次覚醒で獲得：<span id="prestigeGain">0</span></div>
+                <button id="prestigeBtn" class="btn warn block">覚醒する</button>
+              </div>
+              <div id="rebirthList" class="rebirth-list"></div>
             </div>
-            <div id="rebirthList" class="rebirth-list"></div>
-          </div>
-        </section>
+          </section>
 
-        <section class="panel job-panel">
-          <header class="panel-header">
-            <h2>転職</h2>
-          </header>
-          <div id="jobPanel" class="panel-body job-body"></div>
-        </section>
+          <section class="panel job-panel">
+            <header class="panel-header">
+              <h2>転職</h2>
+            </header>
+            <div id="jobPanel" class="panel-body job-body"></div>
+          </section>
 
-        <section class="panel feature-panel">
-          <header class="panel-header">
-            <h2>転生特典</h2>
-          </header>
-          <div id="featurePanel" class="panel-body feature-body"></div>
+          <section class="panel feature-panel">
+            <header class="panel-header">
+              <h2>転生特典</h2>
+            </header>
+            <div id="featurePanel" class="panel-body feature-body"></div>
+          </section>
         </section>
+      </section>
 
-        <section class="panel system-panel">
-          <header class="panel-header">
-            <h2>システム</h2>
-          </header>
-          <div class="panel-body system-body">
-            <button id="saveBtn" class="btn good">保存</button>
-            <button id="loadBtn" class="btn ghost">読込</button>
-            <button id="resetBtn" class="btn danger">ハードリセット</button>
-          </div>
+      <section class="tab-panel" data-tab-panel="system">
+        <section class="column column-right">
+          <section class="panel system-panel">
+            <header class="panel-header">
+              <h2>システム</h2>
+            </header>
+            <div class="panel-body system-body">
+              <button id="saveBtn" class="btn good">保存</button>
+              <button id="loadBtn" class="btn ghost">読込</button>
+              <button id="resetBtn" class="btn danger">ハードリセット</button>
+            </div>
+          </section>
         </section>
       </section>
     </main>

--- a/js/main.js
+++ b/js/main.js
@@ -105,14 +105,65 @@ const featureHandlers = {
   }
 };
 
+
+function setupMainTabs(){
+  const tabButtons = Array.from(document.querySelectorAll('.tab-btn'));
+  const panels = Array.from(document.querySelectorAll('.tab-panel'));
+  if(!tabButtons.length || !panels.length) return;
+
+  const activate = (target)=>{
+    tabButtons.forEach(btn=> btn.classList.toggle('active', btn.dataset.tabTarget===target));
+    panels.forEach(panel=> panel.classList.toggle('active', panel.dataset.tabPanel===target));
+  };
+
+  tabButtons.forEach(btn=>{
+    btn.addEventListener('click', ()=> activate(btn.dataset.tabTarget));
+  });
+  activate('growth');
+}
+
+function animateTapEffects(){
+  const tapBtn = document.getElementById('tapBtn');
+  const tapFx = document.getElementById('tapFx');
+  if(tapBtn){
+    tapBtn.classList.remove('burst');
+    void tapBtn.offsetWidth;
+    tapBtn.classList.add('burst');
+  }
+  if(!tapFx) return;
+  for(let i=0; i<10; i+=1){
+    const spark = document.createElement('span');
+    spark.className='spark';
+    spark.style.setProperty('--dx', `${(Math.random()-0.5)*160}px`);
+    spark.style.setProperty('--dy', `${(Math.random()-0.5)*120}px`);
+    spark.style.animationDelay = `${Math.random()*120}ms`;
+    tapFx.appendChild(spark);
+    setTimeout(()=> spark.remove(), 900);
+  }
+}
+
+let __lastPowerForAnim = new Decimal(0);
+function animatePowerPulse(){
+  const powerEl = document.getElementById('power');
+  if(!powerEl) return;
+  if(state.power.gt(__lastPowerForAnim)){
+    powerEl.classList.remove('pulse');
+    void powerEl.offsetWidth;
+    powerEl.classList.add('pulse');
+  }
+  __lastPowerForAnim = state.power;
+}
+
 function update(){
   renderAll(state, performRebirth, featureHandlers);
+  animatePowerPulse();
 }
 
 document.getElementById('tapBtn').addEventListener('click', ()=>{
   const jb = getJobBonuses(state.job);
   const mult = rebirthMultiplier(state.rebirth) * (state.hyperActive?10:1) * jb.tap;
   state.power = state.power.plus(clickGainByLevel(state.clickLv).times(mult));
+  animateTapEffects();
   update();
 });
 
@@ -170,7 +221,9 @@ document.getElementById('prestigeBtn').addEventListener('click', ()=>{
 });
 
 // initial render
+setupMainTabs();
 update();
+__lastPowerForAnim = state.power;
 try{ const v=document.getElementById('version'); if(v) v.textContent = VERSION; }catch{}
 try{ bindFormatToggle && bindFormatToggle(state, featureHandlers); }catch{}
 

--- a/style.css
+++ b/style.css
@@ -36,9 +36,54 @@ body {
   font-family: var(--font-body);
   font-size: 18px;
   line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.ambient-layer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.ambient-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(8px);
+  opacity: 0.45;
+  animation: floatOrb 12s ease-in-out infinite alternate;
+}
+
+.orb-a {
+  width: 240px;
+  height: 240px;
+  top: 8%;
+  left: 4%;
+  background: radial-gradient(circle, rgba(255, 128, 213, 0.4), rgba(255, 128, 213, 0));
+}
+
+.orb-b {
+  width: 300px;
+  height: 300px;
+  top: 55%;
+  right: 8%;
+  background: radial-gradient(circle, rgba(182, 140, 255, 0.45), rgba(182, 140, 255, 0));
+  animation-duration: 16s;
+}
+
+.orb-c {
+  width: 180px;
+  height: 180px;
+  bottom: 5%;
+  left: 35%;
+  background: radial-gradient(circle, rgba(255, 218, 106, 0.35), rgba(255, 218, 106, 0));
+  animation-duration: 10s;
 }
 
 .page {
+  position: relative;
+  z-index: 1;
   max-width: 1200px;
   margin: 0 auto;
   padding: 32px 20px 48px;
@@ -77,10 +122,49 @@ body {
   letter-spacing: 0.04em;
 }
 
+.main-tabs {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  border: 1px solid var(--panel-highlight);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-main);
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.tab-btn.active {
+  background: linear-gradient(135deg, var(--accent), var(--lavender));
+  color: #180920;
+  box-shadow: 0 8px 22px rgba(255, 128, 213, 0.3);
+}
+
 .layout {
-  display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 24px;
+  display: block;
+}
+
+.tab-panel {
+  display: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.99);
+  transform-origin: top center;
+}
+
+.tab-panel.active {
+  display: block;
+  animation: tabIn 0.35s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
 }
 
 .column {
@@ -147,6 +231,10 @@ body {
   font-weight: 800;
 }
 
+.score-value.pulse {
+  animation: powerPulse 0.35s ease;
+}
+
 .score-pill {
   display: inline-flex;
   align-items: center;
@@ -170,6 +258,33 @@ body {
 .tap-action {
   display: flex;
   justify-content: center;
+}
+
+.tap-zone {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.tap-fx {
+  position: absolute;
+  inset: -28px;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.tap-fx .spark {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #fff 0%, #ffd7f4 45%, rgba(255, 128, 213, 0.05) 100%);
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  animation: sparkle 800ms ease forwards;
 }
 
 .upgrade-block {
@@ -252,6 +367,10 @@ body {
 .btn.main {
   font-size: 18px;
   padding: 18px 32px;
+}
+
+.btn.main.burst {
+  animation: tapBurst 0.28s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .btn.sub {
@@ -483,11 +602,43 @@ body.rebirth-flash::before {
   100% { opacity: 0; }
 }
 
-@media (max-width: 1024px) {
-  .layout {
-    grid-template-columns: 1fr;
-  }
+@keyframes tabIn {
+  0% { opacity: 0; transform: translateY(8px) scale(0.99); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
 
+@keyframes powerPulse {
+  0% { transform: scale(1); filter: drop-shadow(0 0 0 rgba(255, 128, 213, 0)); }
+  50% { transform: scale(1.05); filter: drop-shadow(0 0 14px rgba(255, 128, 213, 0.75)); }
+  100% { transform: scale(1); filter: drop-shadow(0 0 0 rgba(255, 128, 213, 0)); }
+}
+
+@keyframes tapBurst {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+@keyframes sparkle {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.2);
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(1.2);
+  }
+}
+
+@keyframes floatOrb {
+  0% { transform: translateY(0) translateX(0) scale(1); }
+  100% { transform: translateY(-18px) translateX(14px) scale(1.05); }
+}
+
+@media (max-width: 1024px) {
   .column-left,
   .column-right {
     gap: 20px;
@@ -511,7 +662,8 @@ body.rebirth-flash::before {
     grid-template-columns: 1fr;
   }
 
-  .buttons .row {
+  .buttons .row,
+  .main-tabs {
     flex-direction: column;
   }
 }


### PR DESCRIPTION
### Motivation
- Convert the single-page layout into a tabbed interface to separate growth, advanced, and system panels for clearer navigation.
- Improve visual polish by adding ambient background orbs and interactive tap/power animations to increase player feedback.
- Add small accessibility/structure improvements like `aria` attributes for main tabs.

### Description
- Restructured `index.html` to group content into three main tabs (`data-tab-target`: `growth`, `advanced`, `system`) with `nav.main-tabs` and corresponding `section.tab-panel` containers and `aria-label` on the tabs.
- Added an ambient background layer in `index.html` with three orb elements and associated CSS in `style.css` to render blurred floating orbs (`.ambient-layer`, `.ambient-orb`, `.orb-a/.orb-b/.orb-c`).
- Implemented tab activation and panel switching in `js/main.js` via `setupMainTabs()` and wired tab buttons (`.tab-btn`) to toggle `.active` on panels and buttons.
- Added click/tap visual effects and power-change animation: `animateTapEffects()` appends sparkle elements into the new `#tapFx` container and `animatePowerPulse()` toggles a `.pulse` state on `#power`, and both are invoked from the tap handler and `update()` respectively.
- Updated markup around tap button to include `.tap-zone` and `.tap-fx` and added many CSS animations and UI styles (`tabIn`, `powerPulse`, `tapBurst`, `sparkle`, `floatOrb`) and style updates for tabs, pulses, and tap bursts.
- Kept game logic intact while adding UI hooks; initial tab activation (`activate('growth')`) is run on load and `__lastPowerForAnim` is initialized from `state.power`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a8684c08331a67e6fccfadc7de5)