### PR TITLE
タブUIの余白活用と縦長解消のための2カラム再配置

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,111 +30,119 @@
 
     <main class="layout tab-panels">
       <section class="tab-panel active" data-tab-panel="growth">
-        <section class="column column-left">
-          <section class="panel score-panel">
-            <header class="panel-header">
-              <h2>ステータス</h2>
-            </header>
-            <div class="panel-body score-body">
-              <div class="score-line">
-                <span class="score-label">エンジェルハート</span>
-                <span id="power" class="score-value">0</span>
-              </div>
-              <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
-            </div>
-          </section>
-
-          <section class="panel click-panel">
-            <header class="panel-header">
-              <h2>エンジェルハートタップ</h2>
-              <p class="panel-sub">タップしてエンジェルハートを獲得</p>
-            </header>
-            <div class="panel-body click-body">
-              <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
-              <div class="tap-action">
-                <div class="tap-zone">
-                  <button id="tapBtn" class="btn main">ハートタップ！</button>
-                  <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
+        <div class="tab-grid growth-grid">
+          <section class="column column-left">
+            <section class="panel score-panel compact-panel">
+              <header class="panel-header">
+                <h2>ステータス</h2>
+              </header>
+              <div class="panel-body score-body">
+                <div class="score-line">
+                  <span class="score-label">エンジェルハート</span>
+                  <span id="power" class="score-value">0</span>
                 </div>
+                <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
               </div>
+            </section>
 
-              <div class="upgrade-block">
-                <div class="upgrade-head">
-                  <h3>メイドスマイル強化</h3>
-                  <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
-                </div>
-
-                <dl class="upgrade-detail">
-                  <div>
-                    <dt>単体強化（+1）</dt>
-                    <dd>
-                      スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
-                      全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
-                    </dd>
+            <section class="panel click-panel">
+              <header class="panel-header">
+                <h2>エンジェルハートタップ</h2>
+                <p class="panel-sub">タップしてエンジェルハートを獲得</p>
+              </header>
+              <div class="panel-body click-body">
+                <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
+                <div class="tap-action">
+                  <div class="tap-zone">
+                    <button id="tapBtn" class="btn main">ハートタップ！</button>
+                    <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
                   </div>
-                  <div>
-                    <dt>まとめ強化</dt>
-                    <dd>
-                      スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
-                      全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
-                    </dd>
-                  </div>
-                </dl>
+                </div>
 
-                <div class="upgrade-buttons">
-                  <button id="upgradeClick" class="btn sub">単体強化</button>
-                  <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
+                <div class="upgrade-block">
+                  <div class="upgrade-head">
+                    <h3>メイドスマイル強化</h3>
+                    <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
+                  </div>
+
+                  <dl class="upgrade-detail">
+                    <div>
+                      <dt>単体強化（+1）</dt>
+                      <dd>
+                        スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
+                        全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>まとめ強化</dt>
+                      <dd>
+                        スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
+                        全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <div class="upgrade-buttons">
+                    <button id="upgradeClick" class="btn sub">単体強化</button>
+                    <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
+                  </div>
                 </div>
               </div>
-            </div>
+          </section>
           </section>
 
-          <section class="panel generator-panel">
-            <header class="panel-header">
-              <h2>ジェネレーター</h2>
-              <p class="panel-sub">購入はピンク、強化はラベンダーで表示されます</p>
-            </header>
-            <div class="panel-body">
-              <div id="genlist" class="genlist"></div>
-            </div>
+          <section class="column column-right">
+            <section class="panel generator-panel stretch-panel">
+              <header class="panel-header">
+                <h2>ジェネレーター</h2>
+                <p class="panel-sub">購入はピンク、強化はラベンダーで表示されます</p>
+              </header>
+              <div class="panel-body">
+                <div id="genlist" class="genlist"></div>
+              </div>
+            </section>
           </section>
-        </section>
+        </div>
       </section>
 
       <section class="tab-panel" data-tab-panel="advanced">
-        <section class="column column-right">
-          <section class="panel prestige-panel">
-            <header class="panel-header">
-              <h2>アイドル覚醒</h2>
-            </header>
-            <div class="panel-body">
-              <div class="info-box muted">所持スタークリスタル：<span id="prestigeCurr">0</span></div>
-              <div class="info-box">
-                <div>次覚醒で獲得：<span id="prestigeGain">0</span></div>
-                <button id="prestigeBtn" class="btn warn block">覚醒する</button>
+        <div class="tab-grid advanced-grid">
+          <section class="column column-left">
+            <section class="panel prestige-panel">
+              <header class="panel-header">
+                <h2>アイドル覚醒</h2>
+              </header>
+              <div class="panel-body">
+                <div class="info-box muted">所持スタークリスタル：<span id="prestigeCurr">0</span></div>
+                <div class="info-box">
+                  <div>次覚醒で獲得：<span id="prestigeGain">0</span></div>
+                  <button id="prestigeBtn" class="btn warn block">覚醒する</button>
+                </div>
+                <div id="rebirthList" class="rebirth-list"></div>
               </div>
-              <div id="rebirthList" class="rebirth-list"></div>
-            </div>
+            </section>
           </section>
 
-          <section class="panel job-panel">
-            <header class="panel-header">
-              <h2>転職</h2>
-            </header>
-            <div id="jobPanel" class="panel-body job-body"></div>
-          </section>
+          <section class="column column-right">
+            <section class="panel job-panel compact-panel">
+              <header class="panel-header">
+                <h2>転職</h2>
+              </header>
+              <div id="jobPanel" class="panel-body job-body"></div>
+            </section>
 
-          <section class="panel feature-panel">
-            <header class="panel-header">
-              <h2>転生特典</h2>
-            </header>
-            <div id="featurePanel" class="panel-body feature-body"></div>
+            <section class="panel feature-panel compact-panel">
+              <header class="panel-header">
+                <h2>転生特典</h2>
+              </header>
+              <div id="featurePanel" class="panel-body feature-body"></div>
+            </section>
           </section>
-        </section>
+        </div>
       </section>
 
       <section class="tab-panel" data-tab-panel="system">
-        <section class="column column-right">
+        <section class="column column-right system-column">
           <section class="panel system-panel">
             <header class="panel-header">
               <h2>システム</h2>

--- a/style.css
+++ b/style.css
@@ -155,6 +155,13 @@ body {
   display: block;
 }
 
+.tab-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.25fr);
+  gap: 24px;
+  align-items: start;
+}
+
 .tab-panel {
   display: none;
   opacity: 0;
@@ -171,6 +178,19 @@ body {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  min-width: 0;
+}
+
+.system-column {
+  max-width: 760px;
+}
+
+.compact-panel .panel-body {
+  padding-top: 16px;
+}
+
+.stretch-panel {
+  min-height: 100%;
 }
 
 .panel {
@@ -520,8 +540,8 @@ body {
 }
 
 .gen {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(260px, 1.1fr);
   gap: 16px;
   padding: 18px;
   border-radius: 16px;
@@ -639,9 +659,18 @@ body.rebirth-flash::before {
 }
 
 @media (max-width: 1024px) {
+  .tab-grid {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
   .column-left,
   .column-right {
     gap: 20px;
+  }
+
+  .gen {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
### Motivation
- 右側にできていた余白を有効活用して、複数タブ化によるページの縦長化を抑え、情報を見やすく整列するためのレイアウト改善を行いました。

### Description
- `index.html` を編集して育成タブを `tab-grid` の左右2カラム化にし、左カラムに「ステータス／タップ強化」を、右カラムに「ジェネレーター」を配置しました。 
- 同様に覚醒・拡張タブも `tab-grid` にして左に「覚醒」、右に「転職／転生特典」を振り分け、システムタブには `system-column` を付与して幅を整理しました。 
- `style.css` に `.tab-grid`、`.compact-panel`、`.stretch-panel`、`.system-column` を追加し、デスクトップでは2カラム、1024px以下は1カラムへフォールバックするレスポンシブ調整を行いました。 
- ジェネレーターカード `.gen` を2カラムのグリッドに変更してカード内の横展開を改善し、モバイルでは1カラムに戻るようにしました。

### Testing
- `git diff --check` を実行して差分の基本整合性を確認しエラーはありませんでした（成功）。
- `node --check js/main.js && node --check js/ui.js && node --check js/data.js` を実行しましたが、`js/main.js` がブラウザ向けの ES module（`export` を使用）であるため CommonJS 環境の構文チェックで失敗しました（想定される環境差による失敗）。
- その他の自動テストは未設定で、変更はスタイル／マークアップのレイアウト調整に限定されています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebaf1103708331b5b5b23f00d9372a)