### PR TITLE
Refactor growth screen layout; add job portrait/status and update UI logic/styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,77 +30,96 @@
 
     <main class="layout tab-panels">
       <section class="tab-panel active" data-tab-panel="growth">
-        <div class="tab-grid growth-grid">
-          <section class="column column-left">
-            <section class="panel score-panel compact-panel">
-              <header class="panel-header">
-                <h2>ステータス</h2>
-              </header>
-              <div class="panel-body score-body">
-                <div class="score-line">
-                  <span class="score-label">エンジェルハート</span>
-                  <span id="power" class="score-value">0</span>
+        <div class="growth-grid">
+          <div class="growth-top">
+            <section class="column column-left">
+              <section class="panel score-panel compact-panel">
+                <header class="panel-header">
+                  <h2>ステータス</h2>
+                </header>
+                <div class="panel-body score-body">
+                  <div class="score-line">
+                    <span class="score-label">エンジェルハート</span>
+                    <span id="power" class="score-value">0</span>
+                  </div>
+                  <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
+                  <div class="status-extra">
+                    <div class="status-row">現在職業：<span id="currentJob">魔法少女</span></div>
+                    <div class="status-row">転生段階：<span id="currentRebirth">0</span></div>
+                  </div>
+                  <div class="job-portrait" id="jobPortrait" aria-label="現在職業の画像">
+                    <span id="jobPortraitEmoji" class="job-emoji" aria-hidden="true">✨</span>
+                    <span id="jobPortraitLabel" class="job-portrait-label">魔法少女</span>
+                  </div>
                 </div>
-                <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
-              </div>
+              </section>
+
+              <section class="panel click-panel">
+                <header class="panel-header">
+                  <h2>メイドスマイル強化</h2>
+                  <p class="panel-sub">タップ効率と全体倍率を底上げします</p>
+                </header>
+                <div class="panel-body click-body">
+                  <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
+
+                  <div class="upgrade-block">
+                    <div class="upgrade-head">
+                      <h3>クリックレベル</h3>
+                      <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
+                    </div>
+
+                    <dl class="upgrade-detail">
+                      <div>
+                        <dt>単体強化（+1）</dt>
+                        <dd>
+                          スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
+                          全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>まとめ強化</dt>
+                        <dd>
+                          スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
+                          全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
+                        </dd>
+                      </div>
+                    </dl>
+
+                    <div class="upgrade-buttons">
+                      <button id="upgradeClick" class="btn sub">単体強化</button>
+                      <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
+                    </div>
+                  </div>
+                </div>
+              </section>
             </section>
 
-            <section class="panel click-panel">
-              <header class="panel-header">
-                <h2>エンジェルハートタップ</h2>
-                <p class="panel-sub">タップしてエンジェルハートを獲得</p>
-              </header>
-              <div class="panel-body click-body">
-                <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
-                <div class="tap-action">
-                  <div class="tap-zone">
-                    <button id="tapBtn" class="btn main">ハートタップ！</button>
-                    <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
+            <section class="column column-center tap-column">
+              <section class="panel tap-panel compact-panel">
+                <header class="panel-header">
+                  <h2>エンジェルハートタップ</h2>
+                  <p class="panel-sub">中央のボタンを連打して稼ごう</p>
+                </header>
+                <div class="panel-body tap-panel-body">
+                  <div class="tap-action">
+                    <div class="tap-zone">
+                      <button id="tapBtn" class="btn main">ハートタップ！</button>
+                      <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
+                    </div>
                   </div>
                 </div>
-
-                <div class="upgrade-block">
-                  <div class="upgrade-head">
-                    <h3>メイドスマイル強化</h3>
-                    <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
-                  </div>
-
-                  <dl class="upgrade-detail">
-                    <div>
-                      <dt>単体強化（+1）</dt>
-                      <dd>
-                        スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
-                        全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>まとめ強化</dt>
-                      <dd>
-                        スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
-                        全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
-                      </dd>
-                    </div>
-                  </dl>
-
-                  <div class="upgrade-buttons">
-                    <button id="upgradeClick" class="btn sub">単体強化</button>
-                    <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
-                  </div>
-                </div>
-              </div>
-          </section>
-          </section>
-
-          <section class="column column-right">
-            <section class="panel generator-panel stretch-panel">
-              <header class="panel-header">
-                <h2>ジェネレーター</h2>
-                <p class="panel-sub">購入はピンク、強化はラベンダーで表示されます</p>
-              </header>
-              <div class="panel-body">
-                <div id="genlist" class="genlist"></div>
-              </div>
+              </section>
             </section>
+          </div>
+
+          <section class="panel generator-panel stretch-panel">
+            <header class="panel-header">
+              <h2>ジェネレーター</h2>
+              <p class="panel-sub">購入はピンク、強化はラベンダーで表示されます</p>
+            </header>
+            <div class="panel-body">
+              <div id="genlist" class="genlist"></div>
+            </div>
           </section>
         </div>
       </section>

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,6 +1,6 @@
 function setBtnState(btn, enabled){ if(!btn) return; btn.disabled=!enabled; btn.classList.toggle('is-disabled', !enabled); }
 import { fmt, getFormatMode, setFormatMode } from './format.js';
-import { JOBS, JOB_GROUPS, getJobBonuses } from './jobs.js';
+import { JOBS, JOB_GROUPS, JOB_MAP, getJobBonuses } from './jobs.js';
 import { clickGainByLevel, clickNextCost, globalMultiplier, clickTotalCost, maxAffordableClicks } from './click.js';
 import {
   nextUnitCost, totalCostUnits, maxAffordableUnits, buyUnits,
@@ -62,6 +62,21 @@ export function renderClick(state){
   }
 
 function setText(id, value){ const n=document.getElementById(id); if(n) n.textContent = value; }
+function resolveJobEmoji(jobId){
+  if(jobId==='magical') return '✨';
+  const group = JOB_GROUPS.find(g=> g.jobs.some(j=>j.id===jobId));
+  if(!group) return '💖';
+  const iconMap = {
+    magic:'🪄',
+    maid:'🫖',
+    angel:'😇',
+    idol:'🎤',
+    reaper:'🖤',
+    scholar:'📚',
+  };
+  return iconMap[group.id] || '💖';
+}
+
 export function renderKPI(state){
   const jb = getJobBonuses(state.job);
   setText('power', fmt(state.power));
@@ -69,6 +84,12 @@ export function renderKPI(state){
   setText('pps', fmt(pps));
   setText('prestigeCurr', fmt(state.prestige||0));
   setText('prestigeGain', fmt(prestigeGain(state.power) * jb.prestige));
+
+  const currentJob = JOB_MAP[state.job]?.name || '魔法少女';
+  setText('currentJob', currentJob);
+  setText('currentRebirth', `第${(state.rebirth||0)}転生`);
+  setText('jobPortraitLabel', currentJob);
+  setText('jobPortraitEmoji', resolveJobEmoji(state.job));
 }
 
 export function renderRebirths(state, onRebirth){

--- a/style.css
+++ b/style.css
@@ -266,6 +266,64 @@ body {
   font-size: 15px;
 }
 
+
+.growth-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.growth-top {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(260px, 0.8fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.status-extra {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.status-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.job-portrait {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--panel-highlight);
+  background: linear-gradient(135deg, rgba(255, 128, 213, 0.15), rgba(182, 140, 255, 0.12));
+}
+
+.job-emoji {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.job-portrait-label {
+  font-weight: 700;
+}
+
 .click-body {
   gap: 24px;
 }
@@ -278,6 +336,22 @@ body {
 .tap-action {
   display: flex;
   justify-content: center;
+}
+
+
+.tap-column {
+  justify-content: center;
+  align-self: stretch;
+}
+
+.tap-panel {
+  position: sticky;
+  top: 18px;
+}
+
+.tap-panel-body {
+  padding-top: 28px;
+  padding-bottom: 28px;
 }
 
 .tap-zone {
@@ -534,16 +608,16 @@ body {
 }
 
 .genlist {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  gap: 14px;
 }
 
 .gen {
   display: grid;
-  grid-template-columns: minmax(220px, 1fr) minmax(260px, 1.1fr);
-  gap: 16px;
-  padding: 18px;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  padding: 16px;
   border-radius: 16px;
   border: 1px solid var(--panel-border);
   background: rgba(255, 255, 255, 0.03);
@@ -658,10 +732,28 @@ body.rebirth-flash::before {
   100% { transform: translateY(-18px) translateX(14px) scale(1.05); }
 }
 
+@media (max-width: 1180px) {
+  .growth-top {
+    grid-template-columns: minmax(280px, 1fr) minmax(280px, 0.95fr);
+  }
+
+  .tap-panel {
+    position: static;
+  }
+
+  .genlist {
+    grid-template-columns: repeat(2, minmax(260px, 1fr));
+  }
+}
+
 @media (max-width: 1024px) {
   .tab-grid {
     grid-template-columns: 1fr;
     gap: 20px;
+  }
+
+  .growth-top {
+    grid-template-columns: 1fr;
   }
 
   .column-left,
@@ -669,7 +761,7 @@ body.rebirth-flash::before {
     gap: 20px;
   }
 
-  .gen {
+  .genlist {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Reorganize the growth tab to improve visual hierarchy and surface current job and rebirth state to the player.
- Provide a compact, centered tap UI and make generator cards more responsive and grid-driven.
- Add visual affordances (job portrait/emoji) to make role information clearer in the KPI area.

### Description
- Restructured the growth tab markup in `index.html` by introducing `.growth-grid` and `.growth-top`, moving the tap button into a centered `tap-panel`, and reorganizing generator markup into a responsive grid.
- Added new status elements (`#currentJob`, `#currentRebirth`, `#jobPortrait`, `#jobPortraitEmoji`, `#jobPortraitLabel`) and updated the click/upgrade panel labels and headings for clarity.
- Updated `js/ui.js` to import `JOB_MAP`, added `resolveJobEmoji` to map jobs to emoji, and set job/portrait/rebirth texts in `renderKPI` using `JOB_MAP` and `rebirth` state.
- Overhauled `style.css` with styles for `.growth-grid`, `.growth-top`, `.status-extra`, `.job-portrait`, adjusted `.genlist` to a two-column grid, updated `.gen` layout and tap panel behavior, and added responsive media query adjustments.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6bd3bf2c8331b0f02b43be343dc7)