### PR TITLE
ジェネレーター一覧を2列の正方形セル表示に変更

### DIFF
--- a/style.css
+++ b/style.css
@@ -609,18 +609,22 @@ body {
 
 .genlist {
   display: grid;
-  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
   gap: 14px;
 }
 
 .gen {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   gap: 14px;
   padding: 16px;
   border-radius: 16px;
   border: 1px solid var(--panel-border);
   background: rgba(255, 255, 255, 0.03);
+  min-height: 320px;
+  aspect-ratio: 1 / 1;
 }
 
 .gen-left {
@@ -742,7 +746,7 @@ body.rebirth-flash::before {
   }
 
   .genlist {
-    grid-template-columns: repeat(2, minmax(260px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -762,7 +766,7 @@ body.rebirth-flash::before {
   }
 
   .genlist {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -786,5 +790,9 @@ body.rebirth-flash::before {
   .buttons .row,
   .main-tabs {
     flex-direction: column;
+  }
+
+  .genlist {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- ジェネレーター一覧を「A/B」「C/D」のように安定して2列に並べ、各ジェネレーターを正方形に近いセルとして視認性を向上するための調整。

### Description
- `.genlist` の `grid-template-columns` を固定的な2列寄りに変更し `minmax(0, 1fr)` を採用して列幅の安定化を行った。 
- `.genlist` に `grid-auto-rows: 1fr` を追加し行高さを揃えてカードをセル状に見せるようにした。 
- `.gen` をグリッドからフレックスに切り替え (`display: flex`) し、`aspect-ratio: 1 / 1` と `min-height: 320px` を追加してカードを正方形に近い比率で表示するようにした。 
- レスポンシブ調整で中間サイズ（<=1024px）でも2列を維持し、モバイル（<=600px）のみ1列表示に切り替えるようメディアクエリを調整した。\
(変更ファイル: `style.css`)

### Testing
- 自動テストは実行していません（このリポジトリの `package.json` にテストスクリプトが未設定のため）。
- 変更は静的なCSSのみのため、ローカルで差分確認と `git` コミットを行い問題なく反映されました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7c5a6d34833199e66dcded9bbcef)