### PR TITLE
ジェネレーター一覧を3列化しセルの余白を削減

### DIFF
--- a/style.css
+++ b/style.css
@@ -609,8 +609,7 @@ body {
 
 .genlist {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-auto-rows: 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
 }
 
@@ -618,13 +617,11 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 14px;
-  padding: 16px;
+  gap: 12px;
+  padding: 14px;
   border-radius: 16px;
   border: 1px solid var(--panel-border);
   background: rgba(255, 255, 255, 0.03);
-  min-height: 320px;
-  aspect-ratio: 1 / 1;
 }
 
 .gen-left {
@@ -657,8 +654,15 @@ body {
 
 .buttons .row {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  flex-wrap: nowrap;
+  gap: 10px;
+}
+
+.buttons .row .btn {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 12px 10px;
+  font-size: 14px;
 }
 
 .row {
@@ -747,6 +751,15 @@ body.rebirth-flash::before {
 
   .genlist {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .buttons .row {
+    flex-wrap: wrap;
+  }
+
+  .buttons .row .btn {
+    padding: 12px 14px;
+    font-size: 15px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- ジェネレーター（ジェネA, ジェネB, ジェネC…）を3列表示にして横並びで見やすくしたいという要望に対応するため。 
- セルを正方形に“見える”ように余白を無駄にせず省スペース化したいという意図に基づく変更。 

### Description
- `style.css` の `.genlist` をデスクトップで `grid-template-columns: repeat(3, ...)` に変更し3列レイアウトを実現しました。 
- 各 `.gen` カードから `min-height` と `aspect-ratio` を削除し、`gap` と `padding` を詰めてカードの無駄な空白を削減しました。 
- ボタン行のスタイルを調整し、広い画面では2ボタンを横並びで均等幅にしつつ、幅が狭くなった際は折り返すレスポンシブ動作を `@media (max-width: 1180px)` 内で復元しました。 
- 変更ファイル：`style.css` のみ。 

### Testing
- `git diff --check` を実行してフォーマット／差分チェックを行い問題なし（成功）。 
- `git status --short` で変更が `style.css` に反映されていることを確認（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda67a37488331b80ec35c4b4ab3bb)