### PR TITLE
育成画面レイアウト再編とジェネレーター強化表示を2行化

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,85 +32,81 @@
       <section class="tab-panel active" data-tab-panel="growth">
         <div class="growth-grid">
           <div class="growth-top">
-            <section class="column column-left">
-              <section class="panel score-panel compact-panel">
-                <header class="panel-header">
-                  <h2>ステータス</h2>
-                </header>
-                <div class="panel-body score-body">
-                  <div class="score-line">
-                    <span class="score-label">エンジェルハート</span>
-                    <span id="power" class="score-value">0</span>
-                  </div>
-                  <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
-                  <div class="status-extra">
-                    <div class="status-row">現在職業：<span id="currentJob">魔法少女</span></div>
-                    <div class="status-row">転生段階：<span id="currentRebirth">0</span></div>
-                  </div>
-                  <div class="job-portrait" id="jobPortrait" aria-label="現在職業の画像">
-                    <span id="jobPortraitEmoji" class="job-emoji" aria-hidden="true">✨</span>
-                    <span id="jobPortraitLabel" class="job-portrait-label">魔法少女</span>
-                  </div>
+          <section class="panel click-panel growth-click">
+            <header class="panel-header">
+              <h2>メイドスマイル強化</h2>
+              <p class="panel-sub">タップ効率と全体倍率を底上げします</p>
+            </header>
+            <div class="panel-body click-body">
+              <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
+
+              <div class="upgrade-block">
+                <div class="upgrade-head">
+                  <h3>クリックレベル</h3>
+                  <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
                 </div>
-              </section>
 
-              <section class="panel click-panel">
-                <header class="panel-header">
-                  <h2>メイドスマイル強化</h2>
-                  <p class="panel-sub">タップ効率と全体倍率を底上げします</p>
-                </header>
-                <div class="panel-body click-body">
-                  <div class="tap-gain">現在のタップ：<span id="tapGain">+1.00</span></div>
-
-                  <div class="upgrade-block">
-                    <div class="upgrade-head">
-                      <h3>クリックレベル</h3>
-                      <div class="level-line">Lv <span id="clickLvNow">0</span> → <span id="clickLvNext">1</span></div>
-                    </div>
-
-                    <dl class="upgrade-detail">
-                      <div>
-                        <dt>単体強化（+1）</dt>
-                        <dd>
-                          スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
-                          全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
-                        </dd>
-                      </div>
-                      <div>
-                        <dt>まとめ強化</dt>
-                        <dd>
-                          スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
-                          全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
-                        </dd>
-                      </div>
-                    </dl>
-
-                    <div class="upgrade-buttons">
-                      <button id="upgradeClick" class="btn sub">単体強化</button>
-                      <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
-                    </div>
+                <dl class="upgrade-detail">
+                  <div>
+                    <dt>単体強化（+1）</dt>
+                    <dd>
+                      スマイル <span id="c1a"></span> → <span id="c1b"></span>（+<span id="c1d"></span>）<br>
+                      全体倍率 <span id="m1a"></span> → <span id="m1b"></span>（+<span id="m1d"></span>）
+                    </dd>
                   </div>
-                </div>
-              </section>
-            </section>
-
-            <section class="column column-center tap-column">
-              <section class="panel tap-panel compact-panel">
-                <header class="panel-header">
-                  <h2>エンジェルハートタップ</h2>
-                  <p class="panel-sub">中央のボタンを連打して稼ごう</p>
-                </header>
-                <div class="panel-body tap-panel-body">
-                  <div class="tap-action">
-                    <div class="tap-zone">
-                      <button id="tapBtn" class="btn main">ハートタップ！</button>
-                      <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
-                    </div>
+                  <div>
+                    <dt>まとめ強化</dt>
+                    <dd>
+                      スマイル <span id="cMa"></span> → <span id="cMb"></span>（+<span id="cMd"></span>）<br>
+                      全体倍率 <span id="mMa"></span> → <span id="mMb"></span>（+<span id="mMd"></span>）
+                    </dd>
                   </div>
+                </dl>
+
+                <div class="upgrade-buttons">
+                  <button id="upgradeClick" class="btn sub">単体強化</button>
+                  <button id="upgradeClickMax" class="btn sub alt">まとめ強化 ×0</button>
                 </div>
-              </section>
-            </section>
-          </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel score-panel compact-panel growth-status">
+            <header class="panel-header">
+              <h2>ステータス</h2>
+            </header>
+            <div class="panel-body score-body">
+              <div class="score-line">
+                <span class="score-label">エンジェルハート</span>
+                <span id="power" class="score-value">0</span>
+              </div>
+              <div class="score-pill">ハート/秒：<span id="pps">0</span></div>
+              <div class="status-extra">
+                <div class="status-row">現在職業：<span id="currentJob">魔法少女</span></div>
+                <div class="status-row">転生段階：<span id="currentRebirth">0</span></div>
+              </div>
+              <div class="job-portrait" id="jobPortrait" aria-label="現在職業の画像">
+                <span id="jobPortraitEmoji" class="job-emoji" aria-hidden="true">✨</span>
+                <span id="jobPortraitLabel" class="job-portrait-label">魔法少女</span>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel tap-panel compact-panel growth-tap">
+            <header class="panel-header">
+              <h2>エンジェルハートタップ</h2>
+              <p class="panel-sub">中央のボタンを連打して稼ごう</p>
+            </header>
+            <div class="panel-body tap-panel-body">
+              <div class="tap-action">
+                <div class="tap-zone">
+                  <button id="tapBtn" class="btn main">ハートタップ！</button>
+                  <div id="tapFx" class="tap-fx" aria-hidden="true"></div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
 
           <section class="panel generator-panel stretch-panel">
             <header class="panel-header">

--- a/js/ui.js
+++ b/js/ui.js
@@ -264,10 +264,12 @@ function genRow(state, g, onUpdate){
       <div class="desc">単体/sec: <span class="eachPps">${fmt(powerFor(g))}</span></div>
       <div class="desc lvline">Lv <span class="lvNow">0</span> → <span class="lvNext">1</span></div>
       <div class="desc upEffect">
-        強化+1効果：単体 <span class="e1a"></span> → <span class="e1b"></span>（+<span class="e1d"></span>）｜全体 <span class="t1a"></span> → <span class="t1b"></span>（+<span class="t1d"></span>）
+        <div>強化+1効果（単体）：<span class="e1a"></span> → <span class="e1b"></span>（+<span class="e1d"></span>）</div>
+        <div>強化+1効果（全体）：<span class="t1a"></span> → <span class="t1b"></span>（+<span class="t1d"></span>）</div>
       </div>
       <div class="desc upEffectMax">
-        まとめ強化効果：単体 <span class="eMa"></span> → <span class="eMb"></span>（+<span class="eMd"></span>）｜全体 <span class="tMa"></span> → <span class="tMb"></span>（+<span class="tMd"></span>）
+        <div>まとめ強化効果（単体）：<span class="eMa"></span> → <span class="eMb"></span>（+<span class="eMd"></span>）</div>
+        <div>まとめ強化効果（全体）：<span class="tMa"></span> → <span class="tMb"></span>（+<span class="tMd"></span>）</div>
       </div>
     </div>
     <div class="gen-right">

--- a/style.css
+++ b/style.css
@@ -275,9 +275,26 @@ body {
 
 .growth-top {
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) minmax(260px, 0.8fr);
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
+  grid-template-areas:
+    "click status"
+    "tap tap";
   gap: 20px;
   align-items: start;
+}
+
+.growth-click {
+  grid-area: click;
+}
+
+.growth-status {
+  grid-area: status;
+}
+
+.growth-tap {
+  grid-area: tap;
+  justify-self: center;
+  width: min(680px, 100%);
 }
 
 .status-extra {
@@ -339,14 +356,13 @@ body {
 }
 
 
-.tap-column {
-  justify-content: center;
-  align-self: stretch;
-}
-
 .tap-panel {
   position: sticky;
   top: 18px;
+}
+
+.growth-tap.tap-panel {
+  position: static;
 }
 
 .tap-panel-body {
@@ -678,6 +694,13 @@ body {
   color: var(--text-muted);
 }
 
+.upEffect,
+.upEffectMax {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .milestone {
   outline: 2px solid #ffe066;
   box-shadow: 0 0 16px rgba(255, 224, 102, 0.6);
@@ -742,7 +765,7 @@ body.rebirth-flash::before {
 
 @media (max-width: 1180px) {
   .growth-top {
-    grid-template-columns: minmax(280px, 1fr) minmax(280px, 0.95fr);
+    grid-template-columns: repeat(2, minmax(260px, 1fr));
   }
 
   .tap-panel {


### PR DESCRIPTION
### Motivation
- 育成タブ上部で表示が読みづらくなっていたため、クリック強化・ステータス・タップボタンを視覚的に分かりやすく配置する目的でレイアウトを整理しました。 
- ジェネレーターの強化後変動表示が単一行で折り返されるため、常に「単体」と「全体」が別行で確実に表示されるようにして可読性を向上させました。

### Description
- `index.html` の育成タブ上部を再構成し、`growth-click`（左上：クリック強化）、`growth-status`（右上：ステータス）、`growth-tap`（下段中央：クリックボタン）の3ブロックに分割しました。 
- `style.css` に `grid-template-areas` を導入して `growth-top` をグリッド配置に変更し、`growth-tap` を下段中央寄せに調整し、`upEffect` / `upEffectMax` を縦並び（2行固定）にするスタイルを追加しました。 
- `js/ui.js` のジェネレーター行テンプレートを修正して、強化表示をこれまでの同一行表現から「単体」と「全体」をそれぞれ独立した行の `<div>` に分割しました。 
- 変更ファイルは `index.html`、`style.css`、`js/ui.js` です。 

### Testing
- `git diff --check` を実行して差分の体裁に問題がないことを確認しました（成功）。
- `node --check js/ui.js && node --check js/main.js` を実行しましたが、このリポジトリの `package.json` は CommonJS 指定のため ES モジュールの `import` を含むファイルに対する `node --check` は環境的に失敗しました（失敗）。
- `node --check --experimental-default-type=module` でも同様のモジュール設定のため構文チェックが失敗しました（失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda9a929ac833193e71b60d9840831)